### PR TITLE
fix(bypass-upstream-boolean-handling): Better handling for upstream booleans on bypass/muting nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ This node works the same way as ``Forward/Bypass on Boolean (Any)``, but instead
 
 ## Changelog
 ### v1.1.1
+* The ``Forward/Bypass on Boolean (Any)`` and ``Forward/Mute on Boolean (Any)`` now search for the parent boolean value(s) of the upstream nodes if they're either ``Boolean AND Operator``, ``Boolean OR Operator`` or ``Boolean flip`` to ensure bypassing even if boolean value is passed by a node instead of the in-node switch.
+
+### v1.1.1
 * added ``Forward/Bypass on Boolean (Any)`` that lets you bypass directly connected node(s) based on a boolean value
 * added ``Forward/Mute on Boolean (Any)`` that lets you mute directly connected node(s) based on a boolean value
 * added ``Boolean AND Operator`` that returns true if both of it's boolean inputs are true, otherwise returns false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "A set of custom nodes for ComfyUI that make workflows easier: load multiple images via a multi-select dialog with preview. The images are instantly uploaded to the input folder and can be output either as a list or a batch. It also includes boolean AND and OR operators as well as a boolean flip for easy workflow branching, along with nodes to bypass or mute other nodes based on a boolean value."
-version = "1.1.1"
+version = "1.1.2"
 license = { file = "LICENSE" }
 
 [project.urls]


### PR DESCRIPTION
- The ``Forward/Bypass on Boolean (Any)`` and ``Forward/Mute on Boolean (Any)`` now search for the parent boolean value(s) of the upstream nodes if they're either ``Boolean AND Operator``, ``Boolean OR Operator`` or ``Boolean flip`` to ensure bypassing even if boolean value is passed by a node instead of the in-node switch.