### PR TITLE
feat(inpaint-helper): Node to merge image into mask of another image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,44 @@ This node accepts any input type and forwards it unchanged. Its pass-through beh
 #### Forward/Mute on Boolean (Any)
 This node works the same way as ``Forward/Bypass on Boolean (Any)``, but instead of bypassing the connected nodes it mutes them. The mute state can be controlled with the built-in boolean switch or by linking an external boolean, and changes are applied instantly in the UI.
 
+### Inpaint helper
+#### Fit Image into BBox Mask
+This node fits an image <b>inside the bounding box region of a mask</b> and places it into a destination image (or a blank canvas). It’s useful for workflows where you want to insert or align a smaller image (e.g. pose, object, logo, patch) into a specific masked region while keeping correct proportions.
+This node does the following:
+- Detects the bounding box (BBox) of your input mask — that is, the smallest rectangle that covers all white/non-zero pixels.
+- Resizes the source image to fit inside (or cover) that bounding box, preserving aspect ratio.
+- Places the resized image at the corresponding position in the destination image.
+- Outputs the final composited image, a stand-alone fitted image, and a mask showing the exact placed region.
+
+You can find an example workflow [here](https://github.com/user-attachments/assets/fb344190-206b-4c15-93ae-cac05c8b6740) for the images generated in the gif below(download and drop image into comfyui).
+
+Parameters:
+| Parameter | Type | Description |
+| -------- | -------- | ------- |
+| source | IMAGE | The image you want to insert (e.g. pose, object, decal). |
+| mask | MASK | Defines where the image will be placed. The white area determines the bounding box. |
+| destination | IMAGE (optional) | The image you’re compositing onto. If not provided, a blank canvas is created. |
+| mode | ``fit`` / ``fill`` | ``fit`` scales the image inside the mask’s box (no crop). ``fill`` covers the box completely (may crop edges). |
+| align_x / align_y | ``center`` / ``left`` / ``right`` and ``center`` / ``top`` / ``bottom`` | Alignment of the fitted image inside the box if the aspect ratio doesn’t match perfectly. |
+| offset_x / offset_y | INT | Manual pixel offset for fine-tuning the placement. |
+| threshold | FLOAT(0-1) | Mask brightness threshold for detecting the box. 0.5 works for most cases. |
+| pad | INT | Expands the bounding box outward by N pixels. |
+| use_source_alpha | BOOLEAN | If true, respects transparency in the source image during paste. |
+| antialias | ``lanczos`` / ``bicubic`` / ``bilinear`` | Resampling method used when resizing the source image. |
+| canvas_w / canvas_h | INT (optional) | Canvas size when no destination image is given. |
+
+Outputs:
+| Parameter | Type | Description |
+| -------- | -------- | ------- |
+| composite | IMAGE | The final composited image (destination + fitted source). |
+| fitted_source | IMAGE | The resized image placed on a blank canvas. |
+| placed_mask | MASK | The exact mask area where the image was placed. |
+| x, y, w, h | INTs | Bounding box coordinates and dimensions used for placement. |
+
+<img width="1567" height="732" alt="Image" src="https://github.com/user-attachments/assets/ce8aa314-33e0-408f-b1dc-c98f966ea1a4" />
+
+![Image](https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f)
+
 ## Changelog
 ### v1.1.2
 * The ``Forward/Bypass on Boolean (Any)`` and ``Forward/Mute on Boolean (Any)`` now search for the parent boolean value(s) of the upstream nodes if they're either ``Boolean AND Operator``, ``Boolean OR Operator`` or ``Boolean flip`` to ensure bypassing even if boolean value is passed by a node instead of the in-node switch.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ComfyUI-vslinx-nodes
-These custom ComfyUI nodes let you quickly load one or multiple images through the default file dialog. They work like the normal "Load Image" node but support multi-select, so you no longer need to create folders or copy file paths manually. The nodes also include a preview, allowing you to see which images have been selected and switch between them using the standard ComfyUI image preview. There are two versions available: one that outputs the images as a list and another that outputs them as a batch.
+A set of custom nodes for ComfyUI that make workflows easier: load multiple images via a multi-select dialog with preview. The images are instantly uploaded to the input folder and can be output either as a list or a batch. It also includes boolean AND and OR operators as well as a boolean flip for easy workflow branching, along with nodes to bypass or mute other nodes based on a boolean value. Includes a ``Fit Image into BBox Mask`` node as well, that precisely fits and places an image into a masked region’s bounding box — ideal for compositing poses, objects, or partial elements into existing images with preserved aspect ratio and alignment options.
 
 ## How to Install
 ### **Recommended**
@@ -81,9 +81,12 @@ Outputs:
 
 <img width="1567" height="732" alt="Image" src="https://github.com/user-attachments/assets/ce8aa314-33e0-408f-b1dc-c98f966ea1a4" />
 
-![Image](https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f)
+<img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v1.1.3
+* added new ``Fit Image into BBox Mask``-Node in it's own ``vsLinx/inpaint`` node-library. This node fits an image <b>inside the bounding box region of a mask</b> and places it into a destination image (or a blank canvas). It’s useful for workflows where you want to insert or align a smaller image (e.g. pose, object, logo, patch) into a specific masked region while keeping correct proportions. It's intended to be used in an inpainting process where you'll pre-process this image and execute a controlnet on the masked area. An example and can be found in the node description above.
+
 ### v1.1.2
 * The ``Forward/Bypass on Boolean (Any)`` and ``Forward/Mute on Boolean (Any)`` now search for the parent boolean value(s) of the upstream nodes if they're either ``Boolean AND Operator``, ``Boolean OR Operator`` or ``Boolean flip`` to ensure bypassing even if boolean value is passed by a node instead of the in-node switch.
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,7 @@ node_list = [
     "multi_image_select",
     "boolean_operator",
     "bypass_helper",
+    "inpaint_helper",
 ]
 
 NODE_CLASS_MAPPINGS = {}

--- a/nodes/inpaint_helper.py
+++ b/nodes/inpaint_helper.py
@@ -1,0 +1,250 @@
+from typing import List, Optional, Tuple
+import numpy as np
+from PIL import Image, ImageDraw
+import torch
+
+# -------------------- tensor <-> PIL helpers --------------------
+
+def _image_tensor_to_pil_list(img: torch.Tensor) -> List[Image.Image]:
+    """
+    Convert ComfyUI IMAGE tensor [B,H,W,C] float32 in [0,1] to list of PIL images.
+    Keeps alpha if present; most ops convert to RGB as needed.
+    """
+    if img.dim() != 4 or img.shape[-1] not in (1,3,4):
+        raise ValueError("IMAGE must be [B,H,W,C] with C in {1,3,4}.")
+    out = []
+    for b in range(img.shape[0]):
+        arr = img[b].detach().cpu().numpy()
+        arr = np.clip(arr, 0.0, 1.0)
+        arr = (arr * 255.0).astype(np.uint8)
+        c = arr.shape[2]
+        if c == 1:
+            out.append(Image.fromarray(np.repeat(arr, 3, axis=2), mode="RGB"))
+        elif c == 3:
+            out.append(Image.fromarray(arr, mode="RGB"))
+        else:  # 4
+            out.append(Image.fromarray(arr, mode="RGBA"))
+    return out
+
+def _mask_any_to_pil_list(mask_like: torch.Tensor,
+                          force_size: Optional[Tuple[int,int]] = None) -> List[Image.Image]:
+    """
+    Accept MASK in shapes:
+      - [B,1,H,W] float/uint8 in [0..1] or [0..255]
+      - [B,H,W]   float/uint8
+      - [B,H,W,C] (IMAGE used as mask) -> luminance
+    Return list of single-channel PIL "L" images in 0..255.
+    """
+    if mask_like.dim() == 4 and mask_like.shape[1] == 1:
+        B, _, H, W = mask_like.shape
+        out = []
+        for i in range(B):
+            arr = mask_like[i,0].detach().cpu().numpy()
+            if arr.dtype != np.float32 and arr.dtype != np.float64:
+                arr = arr.astype(np.float32)
+            if arr.max() <= 1.0:
+                arr = (arr * 255.0).clip(0,255)
+            out.append(Image.fromarray(arr.astype(np.uint8), mode="L"))
+        if force_size and out and out[0].size != force_size:
+            out = [im.resize(force_size, Image.NEAREST) for im in out]
+        return out
+
+    if mask_like.dim() == 3:
+        B, H, W = mask_like.shape
+        out = []
+        for i in range(B):
+            arr = mask_like[i].detach().cpu().numpy()
+            if arr.dtype != np.float32 and arr.dtype != np.float64:
+                arr = arr.astype(np.float32)
+            if arr.max() <= 1.0:
+                arr = (arr * 255.0).clip(0,255)
+            out.append(Image.fromarray(arr.astype(np.uint8), mode="L"))
+        if force_size and out and out[0].size != force_size:
+            out = [im.resize(force_size, Image.NEAREST) for im in out]
+        return out
+
+    if mask_like.dim() == 4 and mask_like.shape[-1] in (1,3,4):
+        imgs = _image_tensor_to_pil_list(mask_like)
+        l = [im.convert("L") for im in imgs]
+        if force_size and l and l[0].size != force_size:
+            l = [im.resize(force_size, Image.NEAREST) for im in l]
+        return l
+
+    raise ValueError("MASK must be [B,1,H,W] or [B,H,W] (or an IMAGE used as mask).")
+
+def _pil_list_to_image_tensor(imgs: List[Image.Image]) -> torch.Tensor:
+    batch = []
+    for im in imgs:
+        arr = np.asarray(im.convert("RGB"), dtype=np.uint8).astype(np.float32) / 255.0
+        batch.append(arr)
+    arrb = np.stack(batch, axis=0)
+    return torch.from_numpy(arrb)
+
+def _pil_list_to_mask_tensor(masks: List[Image.Image]) -> torch.Tensor:
+    batch = []
+    for m in masks:
+        arr = np.asarray(m.convert("L"), dtype=np.uint8).astype(np.float32) / 255.0
+        batch.append(arr[None, ...])  # [1,H,W]
+    arrb = np.stack(batch, axis=0)
+    return torch.from_numpy(arrb)
+
+def _resample_from_name(name: str):
+    name = (name or "lanczos").lower()
+    if name == "bilinear":
+        return Image.BILINEAR
+    if name == "bicubic":
+        return Image.BICUBIC
+    return Image.LANCZOS
+
+def _bbox_from_mask(mask_l: Image.Image, threshold: float = 0.5) -> Optional[Tuple[int,int,int,int]]:
+    arr = np.array(mask_l, dtype=np.uint8)
+    thr = int(round(np.clip(threshold, 0.0, 1.0) * 255))
+    binm = (arr >= thr).astype(np.uint8) * 255
+    pil = Image.fromarray(binm, mode="L")
+    return pil.getbbox()
+
+def _expand_bbox(x0,y0,x1,y1, w,h, pad: int):
+    if pad <= 0:
+        return x0,y0,x1,y1
+    x0 = max(0, x0 - pad); y0 = max(0, y0 - pad)
+    x1 = min(w, x1 + pad); y1 = min(h, y1 + pad)
+    return x0,y0,x1,y1
+
+def _fit_size(src_w, src_h, dst_w, dst_h, mode="fit"):
+    if mode == "fill":
+        s = max(dst_w / src_w, dst_h / src_h)
+    else:
+        s = min(dst_w / src_w, dst_h / src_h)
+    nw = max(1, int(round(src_w * s)))
+    nh = max(1, int(round(src_h * s)))
+    return nw, nh
+
+def _alignment_offset(ax: str, ay: str, box_w: int, box_h: int, content_w: int, content_h: int):
+    if ax == "left": ox = 0
+    elif ax == "right": ox = box_w - content_w
+    else: ox = (box_w - content_w) // 2
+    if ay == "top": oy = 0
+    elif ay == "bottom": oy = box_h - content_h
+    else: oy = (box_h - content_h) // 2
+    return ox, oy
+
+class vsLinx_FitImageIntoBBoxMask:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "source": ("IMAGE",),
+                "mask": ("MASK",),
+                "mode": (["fit","fill"], {"default":"fit"}),
+                "align_x": (["center","left","right"], {"default":"center"}),
+                "align_y": (["center","top","bottom"], {"default":"center"}),
+                "offset_x": ("INT", {"default":0, "min":-4096, "max":4096, "step":1}),
+                "offset_y": ("INT", {"default":0, "min":-4096, "max":4096, "step":1}),
+                "threshold": ("FLOAT", {"default":0.5, "min":0.0, "max":1.0, "step":0.01}),
+                "pad": ("INT", {"default":0, "min":0, "max":4096, "step":1}),
+                "use_source_alpha": ("BOOLEAN", {"default":False}),
+                "antialias": (["lanczos","bicubic","bilinear"], {"default":"lanczos"}),
+            },
+            "optional": {
+                "destination": ("IMAGE",),
+                "canvas_w": ("INT", {"default":1024, "min":16, "max":8192, "step":1}),
+                "canvas_h": ("INT", {"default":1024, "min":16, "max":8192, "step":1}),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE","IMAGE","MASK","INT","INT","INT","INT")
+    RETURN_NAMES = ("composite","fitted_source","placed_mask","x","y","w","h")
+    FUNCTION = "run"
+    CATEGORY = "vsLinx/inpaint"
+
+    def run(
+        self,
+        source: torch.Tensor,
+        mask: torch.Tensor,
+        mode: str = "fit",
+        align_x: str = "center",
+        align_y: str = "center",
+        offset_x: int = 0,
+        offset_y: int = 0,
+        threshold: float = 0.5,
+        pad: int = 0,
+        use_source_alpha: bool = False,
+        antialias: str = "lanczos",
+        destination: Optional[torch.Tensor] = None,
+        canvas_w: int = 1024,
+        canvas_h: int = 1024,
+    ):
+        resample = _resample_from_name(antialias)
+
+        src_list = _image_tensor_to_pil_list(source)
+        if destination is not None:
+            dst_list = _image_tensor_to_pil_list(destination)
+            canvas_size = (dst_list[0].width, dst_list[0].height)
+        else:
+            dst_list = [Image.new("RGB", (canvas_w, canvas_h), (0,0,0))]
+            canvas_size = (canvas_w, canvas_h)
+
+        mask_list = _mask_any_to_pil_list(mask, force_size=canvas_size)
+
+        B = max(len(src_list), len(dst_list), len(mask_list))
+        if len(src_list) == 1 and B > 1: src_list = src_list * B
+        if len(dst_list) == 1 and B > 1: dst_list = dst_list * B
+        if len(mask_list) == 1 and B > 1: mask_list = mask_list * B
+
+        composites, fitted_only, placed_masks = [], [], []
+        out_x = out_y = out_w = out_h = 0
+
+        for idx, (s_img, d_img, m_img) in enumerate(zip(src_list, dst_list, mask_list)):
+            canvas = d_img.copy()
+
+            bb = _bbox_from_mask(m_img, threshold=threshold)
+            if bb is None:
+                composites.append(canvas)
+                fitted_only.append(Image.new("RGB", canvas.size, (0,0,0)))
+                placed_masks.append(Image.new("L", canvas.size, 0))
+                continue
+
+            x0, y0, x1, y1 = _expand_bbox(*bb, canvas.width, canvas.height, pad)
+            box_w = max(1, x1 - x0); box_h = max(1, y1 - y0)
+
+            src_w, src_h = s_img.width, s_img.height
+            new_w, new_h = _fit_size(src_w, src_h, box_w, box_h, mode=mode)
+            ax, ay = _alignment_offset(align_x, align_y, box_w, box_h, new_w, new_h)
+            paste_x = x0 + ax + offset_x
+            paste_y = y0 + ay + offset_y
+
+            s_rgba = s_img if s_img.mode == "RGBA" else s_img.convert("RGBA")
+            fitted = s_rgba.resize((new_w, new_h), resample=resample)
+
+            if use_source_alpha:
+                canvas.paste(fitted.convert("RGB"), (paste_x, paste_y), fitted.split()[-1])
+            else:
+                canvas.paste(fitted.convert("RGB"), (paste_x, paste_y))
+
+            on_black = Image.new("RGB", canvas.size, (0,0,0))
+            if use_source_alpha:
+                on_black.paste(fitted.convert("RGB"), (paste_x, paste_y), fitted.split()[-1])
+            else:
+                on_black.paste(fitted.convert("RGB"), (paste_x, paste_y))
+
+            footprint = Image.new("L", canvas.size, 0)
+            draw = ImageDraw.Draw(footprint)
+            draw.rectangle([paste_x, paste_y, paste_x + new_w - 1, paste_y + new_h - 1], fill=255)
+
+            m_arr = np.array(m_img, dtype=np.uint8)
+            f_arr = np.array(footprint, dtype=np.uint8)
+            placed = Image.fromarray(np.minimum(m_arr, f_arr), mode="L")
+
+            composites.append(canvas); fitted_only.append(on_black); placed_masks.append(placed)
+            if idx == 0:
+                out_x, out_y, out_w, out_h = int(x0), int(y0), int(box_w), int(box_h)
+
+        return (
+            _pil_list_to_image_tensor(composites),
+            _pil_list_to_image_tensor(fitted_only),
+            _pil_list_to_mask_tensor(placed_masks),
+            out_x, out_y, out_w, out_h
+        )
+
+NODE_CLASS_MAPPINGS = {"vsLinx_FitImageIntoBBoxMask": vsLinx_FitImageIntoBBoxMask}
+NODE_DISPLAY_NAME_MAPPINGS = {"vsLinx_FitImageIntoBBoxMask": "Fit Image into BBox Mask"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
-description = "A set of custom nodes for ComfyUI that make workflows easier: load multiple images via a multi-select dialog with preview. The images are instantly uploaded to the input folder and can be output either as a list or a batch. It also includes boolean AND and OR operators as well as a boolean flip for easy workflow branching, along with nodes to bypass or mute other nodes based on a boolean value."
-version = "1.1.2"
+description = "A set of custom nodes for ComfyUI that make workflows easier: load multiple images via a multi-select dialog with preview. The images are instantly uploaded to the input folder and can be output either as a list or a batch. It also includes boolean AND and OR operators as well as a boolean flip for easy workflow branching, along with nodes to bypass or mute other nodes based on a boolean value. Also includes a Fit Image into BBox Mask node that precisely fits and places an image into a masked region’s bounding box — ideal for compositing poses, objects, or partial elements into existing images with preserved aspect ratio and alignment options."
+version = "1.1.3"
 license = { file = "LICENSE" }
 
 [project.urls]


### PR DESCRIPTION
added new ``Fit Image into BBox Mask``-Node in it's own ``vsLinx/inpaint`` node-library. This node fits an image <b>inside the bounding box region of a mask</b> and places it into a destination image (or a blank canvas). It’s useful for workflows where you want to insert or align a smaller image (e.g. pose, object, logo, patch) into a specific masked region while keeping correct proportions. It's intended to be used in an inpainting process where you'll pre-process this image and execute a controlnet on the masked area. An example and can be found in the node description.