### PR TITLE
feat(multiline-wildcard-text): added new Multiline Wildcard Text Node based on Impact-Packs wildcard implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,13 @@ A set of custom nodes for ComfyUI that make workflows easier: load multiple imag
 
 ## Nodes
 
-### Image
+### Text
+#### (Impact-Pack) Multiline Wildcard Text
+Provides a simple multiline text field with a wildcard selector that automatically appends selected wildcards. This node uses the API endpoint from the [Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack) custom node to provide a dropdown that lets you select wildcards to be added to your prompt.  
+This node does not resolve these wildcards by itself and is intended to be passed into the **“Populated Prompt”** field in the Impact-Pack **“ImpactWildcardProcessor”** node.
+<img width="1562" height="447" alt="Image" src="https://github.com/user-attachments/assets/27c5e3e3-4e51-450e-b91d-6f3ef48b2f28" />
 
+### Image
 #### Load (Multiple) Images (List)
 Provides a simple node with a “Select Images” button that lets you choose one or multiple images. After selection, the images are uploaded to your ``input`` folder in ComfyUI (the same behavior as the default Load Image node). The node also includes a preview of the selected images: you can click on an image to switch from the tile view to a full image view. Clicking the X returns you to the tile view, while the numbering in the bottom-right corner allows you to switch between images. <br>
 The node includes a ``max_images`` property that defines how many images can be loaded. If set to 0 or left empty, the number of allowed images is unlimited. <br>
@@ -67,6 +72,9 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.4.0
+- added the "(Impact-Pack) Multiline Wildcard Text"-Node that provides a simple multiline text field with a wildcard selector that automatically appends selected wildcards. 
+
 ### v1.3.1
 * fixed a bug where the ``Power Lora Loader to Prompt (Image Saver)`` could not gather the information of the loras if they were qwen, flux or lumina2 (Z-IMG)
 

--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,7 @@ node_list = [
     "bypass_helper",
     "inpaint_helper",
     "lora_save_helper",
+    "impact_multiline_wildcard_text",
 ]
 
 NODE_CLASS_MAPPINGS = {}

--- a/nodes/impact_multiline_wildcard_text.py
+++ b/nodes/impact_multiline_wildcard_text.py
@@ -1,0 +1,31 @@
+class vsLinx_ImpactMultilineWildcardText:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "text": (
+                    "STRING",
+                    {
+                        "multiline": True,
+                        "default": "",
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("string",)
+    FUNCTION = "output"
+    CATEGORY = "vsLinx/text"
+
+    def output(self, text: str):
+        return (text,)
+
+
+NODE_CLASS_MAPPINGS = {
+    "vsLinx_ImpactMultilineWildcardText": vsLinx_ImpactMultilineWildcardText,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "vsLinx_ImpactMultilineWildcardText": "(Impact-Pack) Multiline Wildcard Text",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "A set of custom nodes for ComfyUI that make workflows easier: load multiple images via a multi-select dialog with preview. The images are instantly uploaded to the input folder and can be output either as a list or a batch. It also includes boolean AND and OR operators as well as a boolean flip for easy workflow branching, along with nodes to bypass or mute other nodes based on a boolean value. Also includes a Fit Image into BBox Mask node that precisely fits and places an image into a masked region’s bounding box — ideal for compositing poses, objects, or partial elements into existing images with preserved aspect ratio and alignment options. Furthermore includes a bridge to connect a rgthree power lora loader to the image saver to persist lora information in metadata."
-version = "1.3.1"
+version = "1.4.0"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/vsLinx_BooleanAndOperator.md
+++ b/web/docs/vsLinx_BooleanAndOperator.md
@@ -1,5 +1,4 @@
 Provides a node with 2 boolean inputs. Outputs True only if <b>both</b> inputs are True. Otherwise returns False.  
-<img width="1284" height="182" alt="Image" src="https://github.com/user-attachments/assets/a7c0a40b-8246-4aa5-806a-ba4d7b749ad9" />
 
 This node does the following:
 - Accepts two boolean inputs and converts them safely to booleans (supports Python bools, NumPy bools, and lists/tuples).

--- a/web/docs/vsLinx_ImpactMultilineWildcardText.md
+++ b/web/docs/vsLinx_ImpactMultilineWildcardText.md
@@ -1,0 +1,35 @@
+# (Impact-Pack) Multiline Wildcard Text
+
+Provides a **multiline text input node** tailored for Impact-Pack wildcards.  
+Works like the default multiline STRING node, but adds a second-line dropdown that lets you **insert wildcard tokens** directly into the text field.
+
+This node does the following:
+- Provides a standard **multiline STRING input** for your prompt text.
+- Adds a frontend **“Add wildcard”** dropdown below the text field.
+- Populates the dropdown with available wildcard names detected from your setup.
+- When you select a wildcard from the dropdown, it is appended to the `text` field, automatically adding `", "` first if the current text doesn’t already end with a comma.
+- Can still be used as a normal multiline text node even if no wildcards are available.
+
+---
+
+## Parameters
+
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| text      | STRING | Base prompt text. This is a standard multiline STRING input; selecting wildcards from the dropdown appends them directly into this field. |
+
+---
+
+## Outputs
+
+| Parameter | Type   | Description |
+| --------- | ------ | ----------- |
+| string    | STRING | The final prompt text, including any wildcards you added via the dropdown. |
+
+---
+
+## Notes
+
+- The dropdown always works on the **visible text field**. You can freely edit, remove, or rearrange wildcard tokens after inserting them.
+- If no wildcards are detected, the dropdown will indicate that none are available, and you can still type your prompt manually as usual.
+- This node does not process the wildcards, it's only used to give a clean interface to add the wildcards to a multiline string, you'll have to connect it to the "Populated Prompt"-Field in the Impact-Pack "ImpactWildcardProcessor"-Node

--- a/web/js/impact_multiline_wildcard_text.js
+++ b/web/js/impact_multiline_wildcard_text.js
@@ -1,0 +1,106 @@
+// ComfyUI/web/extensions/impact_multiline_wildcard_text.js
+
+import { app } from "/scripts/app.js";
+import { api } from "/scripts/api.js";
+
+let wildcards_list = [];
+let wildcards_loaded = false;
+
+async function loadWildcards() {
+    if (wildcards_loaded) return wildcards_list;
+
+    try {
+        const res = await api.fetchApi("/impact/wildcards/list");
+        const data = await res.json();
+
+        if (Array.isArray(data)) {
+            wildcards_list = data;
+        } else if (Array.isArray(data?.data)) {
+            wildcards_list = data.data;
+        } else if (Array.isArray(data?.list)) {
+            wildcards_list = data.list;
+        } else {
+            wildcards_list = [];
+        }
+
+        wildcards_loaded = true;
+    } catch (err) {
+        console.error("vsLinx_ImpactMultilineWildcardText: failed to load wildcards:", err);
+        wildcards_list = [];
+    }
+
+    return wildcards_list;
+}
+
+function insertWildcardIntoText(node, wildcard) {
+    if (!wildcard) return;
+
+    const textWidget =
+        node.widgets?.find((w) => w.name === "text") ?? node.widgets?.[0];
+    if (!textWidget) return;
+
+    const current = textWidget.value || "";
+    let newText = current;
+
+    if (current.trim() !== "" && !current.trim().endsWith(",")) {
+        newText += ", ";
+    }
+
+    newText += wildcard;
+
+    textWidget.value = newText;
+
+    if (Array.isArray(node.widgets_values)) {
+        node.widgets_values[0] = newText;
+    }
+
+    app.canvas.setDirty(true);
+}
+
+function setupWildcardDropdown(node) {
+    if (node.comfyClass !== "vsLinx_ImpactMultilineWildcardText") return;
+
+    const textWidget =
+        node.widgets?.find((w) => w.name === "text") ?? node.widgets?.[0];
+    if (textWidget && textWidget.inputEl) {
+        textWidget.inputEl.placeholder =
+            "Text (multiline)";
+    }
+
+    const dropdown = node.addWidget(
+        "combo",
+        "Add wildcard",
+        "Select wildcard",
+        (value) => {
+            if (!value || value === "Select wildcard") return;
+            insertWildcardIntoText(node, value);
+        },
+        {
+            values: ["Select wildcard"], 
+        }
+    );
+
+    loadWildcards().then((list) => {
+        if (!dropdown.options) dropdown.options = {};
+
+        if (!list || list.length === 0) {
+            dropdown.options.values = ["Select wildcard", "<no wildcards found>"];
+            dropdown.value = "Select wildcard";
+        } else {
+            dropdown.options.values = ["Select wildcard", ...list];
+            dropdown.value = "Select wildcard";
+        }
+
+        app.canvas.setDirty(true);
+    });
+}
+
+app.registerExtension({
+    name: "User.vsLinx_ImpactMultilineWildcardText",
+
+    async nodeCreated(node) {
+        if (node.comfyClass === "vsLinx_ImpactMultilineWildcardText") {
+            setupWildcardDropdown(node);
+        }
+    },
+});


### PR DESCRIPTION
- added the "(Impact-Pack) Multiline Wildcard Text"-Node that provides a simple multiline text field with a wildcard selector that automatically appends selected wildcards. 