### PR TITLE
feat(upscale-by-factor): adds an upscale by factor with model node

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ It also includes a ``fail_if_empty`` property to throw an error if no elements a
 #### Load (Multiple) Images (Batch)
 This node works the same way as the [Load (Multiple) Images (List)](#load-multiple-images-list)-Node but <b>the images are returned as a batch, allowing downstream nodes to process them together.</b>
 
+#### Upscale by Factor (With Model)
+his node upscales an image using a selected <b>upscale model</b> and then resizes the result to a target scale factor. <b>Upscale models typically operate at a fixed scale (e.g. 2× or 4×).</b> This node first runs the model at its native scale, then applies a final resize step to match your requested factor. Minimum is 0.1 scale while the maximum is 8.0 scale.
+<img width="1420" height="602" alt="Image" src="https://github.com/user-attachments/assets/d1845c2e-0d8b-480d-8177-7799f8259b2a" />
+
 ### Boolean
 #### Boolean AND Operator
 Provides a node with 2 boolean inputs. Outputs True only if both inputs are True. Otherwise returns False. <br>
@@ -107,6 +111,12 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.6.0
+- added new "Upscale by Factor (With Model)"-Node that upscales an image to the desired factor of it's original size by using an upscale model + ``nearest-exact``, ``bilinear`` or ``area`` upscaling to resize the image to the desired factor afterwards
+
+### v.1.5.0
+- added new setting that allows you to add previews for all model loaders (+ rgthree subfolder compatible)
+
 ### v.1.4.0
 - added the "(Impact-Pack) Multiline Wildcard Text"-Node that provides a simple multiline text field with a wildcard selector that automatically appends selected wildcards. 
 

--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ node_list = [
     "inpaint_helper",
     "lora_save_helper",
     "impact_multiline_wildcard_text",
+    "upscale_by_factor_with_model"
 ]
 
 NODE_CLASS_MAPPINGS = {}

--- a/nodes/upscale_by_factor_with_model.py
+++ b/nodes/upscale_by_factor_with_model.py
@@ -1,0 +1,65 @@
+import torch
+from comfy import model_management
+import comfy.utils
+
+
+class VSLinx_UpscaleByFactorWithModel:
+    upscale_methods = ["nearest-exact", "bilinear", "area"]
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "upscale_model": ("UPSCALE_MODEL",),
+                "image": ("IMAGE",),
+                "upscale_method": (cls.upscale_methods,),
+                "factor": ("FLOAT", {"default": 2.0, "min": 0.1, "max": 8.0, "step": 0.1}),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("image",)
+    FUNCTION = "upscale"
+    CATEGORY = "vsLinx/image"
+
+    def upscale(self, upscale_model, image, upscale_method, factor):
+        device = model_management.get_torch_device()
+        upscale_model.to(device)
+
+        try:
+            in_img = image.movedim(-1, -3).to(device)
+            s = comfy.utils.tiled_scale(
+                in_img,
+                lambda a: upscale_model(a),
+                tile_x=128 + 64,
+                tile_y=128 + 64,
+                overlap=8,
+                upscale_amount=upscale_model.scale,
+            )
+            upscaled = torch.clamp(s.movedim(-3, -1), min=0.0, max=1.0)
+
+            old_w = int(image.shape[2])
+            old_h = int(image.shape[1])
+            new_w = max(1, int(old_w * float(factor)))
+            new_h = max(1, int(old_h * float(factor)))
+
+            samples = upscaled.movedim(-1, 1)
+            out = comfy.utils.common_upscale(samples, new_w, new_h, upscale_method, crop="disabled")
+            out = out.movedim(1, -1)
+
+            return (out.to("cpu"),)
+
+        finally:
+            try:
+                upscale_model.cpu()
+            except Exception:
+                pass
+
+
+NODE_CLASS_MAPPINGS = {
+    "vsLinx_UpscaleByFactorWithModel": VSLinx_UpscaleByFactorWithModel,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "vsLinx_UpscaleByFactorWithModel": "Upscale by Factor (With Model)",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: load multiple images via a multi-select dialog with preview; images upload instantly to the input folder and can be output as a list or a batch. Includes boolean AND/OR plus a boolean flip for easy branching, and nodes that bypass or mute other nodes based on a boolean value. Also includes “Fit Image into BBox Mask” to precisely fit/place an image into a mask region’s bounding box—ideal for compositing poses, objects, or partial elements—while preserving aspect ratio and offering alignment options. Adds a bridge from rgthree Power LoRA Loader to the image saver to store LoRA info in metadata, plus settings to show previews of all models & LoRAs across all model loaders - compatible with rgthree's subdirectory view."
-version = "1.5.0"
+version = "1.6.0"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/vsLinx_UpscaleByFactorWithModel.md
+++ b/web/docs/vsLinx_UpscaleByFactorWithModel.md
@@ -1,0 +1,26 @@
+This node upscales an image using a selected <b>upscale model</b> and then resizes the result to a target scale factor. <b>Upscale models typically operate at a fixed scale (e.g. 2× or 4×).</b> This node first runs the model at its native scale, then applies a final resize step to match your requested factor.
+
+This node does the following:
+- Upscales the image using the selected ``upscale_model`` via tiled processing (to reduce VRAM usage).
+- Computes the target size from your input image dimensions and the provided ``factor``.
+- Resizes the model output to exactly match that target size using the chosen ``upscale_method``.
+- Returns the final image.
+
+Parameters:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| upscale_model | UPSCALE_MODEL | The upscaling model to use |
+| image | IMAGE | The input image to upscale. |
+| upscale_method | ``nearest-exact`` / ``bilinear`` / ``area`` | The resampling method used for the final resize step to match your target factor. |
+| factor | FLOAT | Target scaling factor relative to the original image size (min: 0.1, max 8.0). |
+
+Outputs:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| image | IMAGE | The final upscaled + resized image. |
+
+Notes:
+- The upscaling model is always applied at its native scale (e.g. 2×/4×). The ``factor`` is achieved by resizing the model output to the target dimensions afterward.
+- For ``factor`` values smaller than the model scale, this results in “upscale then downscale” (often still looks good).
+- For very large factors (e.g. 8× with a 2× model), the additional scaling beyond the model’s native scale is performed by the final resize step (interpolation), which can look softer depending on ``upscale_method``.
+- ``area`` generally works best for downscaling; ``nearest-exact`` preserves hard edges but can look blocky; ``bilinear`` is smoother but may soften details.


### PR DESCRIPTION
- added new "Upscale by Factor (With Model)"-Node that upscales an image to the desired factor of it's original size by using an upscale model + ``nearest-exact``, ``bilinear`` or ``area`` upscaling to resize the image to the desired factor afterwards
- fixed v1.5.0 readme addition to changelog