### PR TITLE
Output original image filenames during batch selection for bulk saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Compatible with well-known ComfyUI custom nodes/plugins that save metadata and/o
 ### Text
 #### (Impact-Pack) Multiline Wildcard Text
 Provides a simple multiline text field with a wildcard selector that automatically appends selected wildcards. This node uses the API endpoint from the [Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack) custom node to provide a dropdown that lets you select wildcards to be added to your prompt.  
-This node does not resolve these wildcards by itself and is intended to be passed into the **“Populated Prompt”** field in the Impact-Pack **“ImpactWildcardProcessor”** node.
+This node does not resolve these wildcards by itself and is intended to be passed into the **“Populated Prompt”** field in the Impact-Pack **“ImpactWildcardProcessor”** node.<br>
 <img width="1562" height="447" alt="Image" src="https://github.com/user-attachments/assets/27c5e3e3-4e51-450e-b91d-6f3ef48b2f28" />
 
 ### Image
@@ -60,11 +60,19 @@ This node does not resolve these wildcards by itself and is intended to be passe
 Provides a simple node with a “Select Images” button that lets you choose one or multiple images. After selection, the images are uploaded to your ``input`` folder in ComfyUI (the same behavior as the default Load Image node). The node also includes a preview of the selected images: you can click on an image to switch from the tile view to a full image view. Clicking the X returns you to the tile view, while the numbering in the bottom-right corner allows you to switch between images. <br>
 The node includes a ``max_images`` property that defines how many images can be loaded. If set to 0 or left empty, the number of allowed images is unlimited. <br>
 It also includes a ``fail_if_empty`` property to throw an error if no elements are being passed, likely caused by images having been deleted or moved from the input folder.
-<b>The images are returned as an image list, allowing downstream nodes to process them one after another.</b> <br>
+Furthermore includes a ``filename_handling`` property that lets you control how the filenames are being output.
+- ``full filename`` will output the full filename without it's extension<br>
+``image (1).png`` will return ``image (1)``
+- ``deduped filename`` will return the filename while removing any automatically appended `` (incrementing number)`` elements that are added when uploading more than 1 picture with the same filename + extension to the comfyui/input folder.
+
+<b>The images and filenames are returned as a list</b>, allowing downstream nodes to process them one after another. <br>
 <img width="1040" height="510" alt="Image" src="https://github.com/user-attachments/assets/83d6c60c-5069-4c3b-9886-0f4cefb64df9" />
 
 #### Load (Multiple) Images (Batch)
-This node works the same way as the [Load (Multiple) Images (List)](#load-multiple-images-list)-Node but <b>the images are returned as a batch, allowing downstream nodes to process them together.</b>
+This node works the same way as the [Load (Multiple) Images (List)](#load-multiple-images-list)-Node but <b>the images are returned as a batch</b>, allowing downstream nodes to process them together while the <b>filenames are returned as a string of all filenames seperated by a comma</b>. <br>
+
+Note that a batch is a tensor of the same shape, if your images have different heights and width they'll be resized to fit one common size of the first image, even if that means that they'll get cropped, resized or padded. <br>
+**Using a batch always implies using uniform dimensions!**
 
 #### Upscale by Factor (With Model)
 his node upscales an image using a selected <b>upscale model</b> and then resizes the result to a target scale factor. <b>Upscale models typically operate at a fixed scale (e.g. 2× or 4×).</b> This node first runs the model at its native scale, then applies a final resize step to match your requested factor. Minimum is 0.1 scale while the maximum is 8.0 scale.
@@ -111,6 +119,9 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.6.1
+- added filename export for ``Load (Multiple) Images (List)`` and ``Load (Multiple) Images (Batch)`` with a node-property to also dedupe the filename to remove `` (number)`` from the name in case of a duplicate filename 
+
 ### v.1.6.0
 - added new "Upscale by Factor (With Model)"-Node that upscales an image to the desired factor of it's original size by using an upscale model + ``nearest-exact``, ``bilinear`` or ``area`` upscaling to resize the image to the desired factor afterwards
 

--- a/nodes/multi_image_select.py
+++ b/nodes/multi_image_select.py
@@ -1,6 +1,4 @@
-import os
-import json
-import re
+import os, json, re
 from typing import List, Tuple
 import numpy as np
 from PIL import Image, ImageOps
@@ -47,58 +45,22 @@ def _parse_paths(s: str) -> List[str]:
 
 def _resolve_existing(rels: List[str]) -> Tuple[List[str], List[str]]:
     """
-    Core Optimization: Prioritize using the actual file paths from the input directory over temporary paths passed from the frontend.
+    Resolve relative paths against the input root, clamp to root,
+    and keep only files that exist and have known image extensions.
+    Returns (existing_abs_paths, missing_rel_paths).
     """
     root = os.path.abspath(_input_root()) + os.sep
     existing: List[str] = []
     missing: List[str] = []
-    
-    # First, retrieve all valid images in the input directory (for matching actual paths).
-    input_files = {}
-    for file in os.listdir(root):
-        if os.path.splitext(file)[1].lower() in IMG_EXTS:
-            # Key: filename without extension (for matching), Value: actual absolute path
-            input_files[os.path.splitext(file)[0].lower()] = os.path.join(root, file)
-
     for rel in rels:
-        # Extract the filename (without extension) from the path passed to the frontend, used to match the actual file in the input directory.
-        rel_basename = os.path.basename(rel)
-        rel_name_noext = os.path.splitext(rel_basename)[0].lower()
-        # Name after the cleaning system suffix (for fuzzy matching)
-        rel_name_clean = re.sub(r'\s*\(\d+\)$', '', rel_name_noext)
-
-        # Prioritize matching actual files in the input directory
-        real_abs_path = None
-        if rel_name_noext in input_files:
-            real_abs_path = input_files[rel_name_noext]
-        elif rel_name_clean in input_files:
-            real_abs_path = input_files[rel_name_clean]
-        else:
-            # Fallback: Resolve according to the original logic.
-            abs_path = os.path.abspath(os.path.join(root, rel))
-            ext_ok = os.path.splitext(rel)[1].lower() in IMG_EXTS
-            in_root = abs_path.startswith(root)
-            if ext_ok and in_root and os.path.isfile(abs_path):
-                real_abs_path = abs_path
-
-        if real_abs_path:
-            existing.append(real_abs_path)
-        else:
+        ext_ok = os.path.splitext(rel)[1].lower() in IMG_EXTS
+        abs_path = os.path.abspath(os.path.join(root, rel))
+        in_root = abs_path.startswith(root)
+        if not (ext_ok and in_root and os.path.isfile(abs_path)):
             missing.append(rel)
+            continue
+        existing.append(abs_path)
     return existing, missing
-
-def _clean_filename(filename: str, keep_legitimate_brackets: bool = True) -> str:
-    """
-    Precision Cleaning: Removes only the automatically added "(number)" suffix, preserving valid parentheses.
-    - keep_legitimate_brackets=True：Retain as test(1).png → test(1), only clean up test (1).png → test
-    """
-    if keep_legitimate_brackets:
-        # The regular expression only matches system suffixes ending with "space + (digit)" (e.g., "2 (2)" → "2", "test(1)" → "test(1)").
-        clean_name = re.sub(r'\s+\(\d+\)$', '', filename)
-    else:
-        # Compatibility Mode: Remove all trailing (numbers) (Not recommended)
-        clean_name = re.sub(r'\(\d+\)$', '', filename)
-    return clean_name
 
 def _fail_if_needed(existing_count: int, missing: List[str], fail_if_empty: bool, node_name: str):
     if fail_if_empty and existing_count == 0:
@@ -112,8 +74,38 @@ def _fail_if_needed(existing_count: int, missing: List[str], fail_if_empty: bool
             f"{node_name}: No valid images found. They may have been moved or deleted from the input folder.{hint}"
         )
 
+# ------------------ filename handling ------------------
+
+FILENAME_HANDLING_OPTIONS = ("full filename", "deduped filename")
+
+def _name_for_output(abs_path: str, handling: str) -> str:
+    """
+    Returns the basename WITHOUT extension per handling.
+      - 'full filename'    -> stem as-is
+      - 'deduped filename' -> stem with ONLY trailing ' (digits)' removed
+                              (space + parentheses). Legitimate 'name(2)' is kept.
+    """
+    base = os.path.basename(abs_path)
+    stem, _ext = os.path.splitext(base)
+
+    if handling == "deduped filename":
+        # remove only " space + (number)" at the end, e.g. 'cat (2)' -> 'cat'
+        stem = re.sub(r"\s+\(\d+\)$", "", stem)
+
+    # default or 'full filename' -> unchanged stem
+    return stem
+
+# -------------------------------------------------------
+
 class VSLinx_LoadSelectedImagesList:
-    DESCRIPTION = "Provides a simple node with a “Select Images” button that lets you choose one or multiple images. After selection, the images are uploaded to your input folder in ComfyUI (the same behavior as the default Load Image node). The node also includes a preview of the selected images. The images are returned as an image list, allowing downstream nodes to process them one after another. Extra: Output filenames without extension."
+    """
+    Reads files listed in `selected_paths` and outputs:
+      - IMAGE list (each item BHWC with B=1)
+      - STRING list of filenames (without extension), per 'filename_handling'.
+    """
+    DESCRIPTION = ("Provides a simple node with a “Select Images” button that lets you choose one or multiple images. "
+                   "After selection, the images are uploaded to your input folder in ComfyUI (same as core). "
+                   "Returns images as a list and a parallel list of filenames (no extension).")
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -125,10 +117,8 @@ class VSLinx_LoadSelectedImagesList:
                     "placeholder": "Filled by the 'Select images' button (JSON array)."
                 }),
                 "fail_if_empty": ("BOOLEAN", {"default": True}),
+                "filename_handling": (FILENAME_HANDLING_OPTIONS, {"default": "full filename"}),
             },
-            "optional": {
-                "keep_legitimate_brackets": ("BOOLEAN", {"default": True}),  # New: Retain valid parentheses?
-            }
         }
 
     RETURN_TYPES = ("IMAGE", "STRING")
@@ -137,7 +127,13 @@ class VSLinx_LoadSelectedImagesList:
     FUNCTION = "load"
     CATEGORY = "vsLinx/image"
 
-    def load(self, selected_paths: str = "", fail_if_empty: bool = True, keep_legitimate_brackets: bool = True, **kwargs):
+    def load(
+        self,
+        selected_paths: str = "",
+        fail_if_empty: bool = True,
+        filename_handling: str = "full filename",
+        **kwargs
+    ):
         if not selected_paths:
             selected_paths = kwargs.get("selected_paths", "")
 
@@ -151,16 +147,13 @@ class VSLinx_LoadSelectedImagesList:
         existing, missing = _resolve_existing(rels)
         _fail_if_needed(len(existing), missing, fail_if_empty, "Load (Multiple) Images (List)")
 
-        images = []
-        filenames = []
+        images: List[torch.Tensor] = []
+        names: List[str] = []
         for abs_path in existing:
             try:
-                img = Image.open(abs_path)
-                images.append(_pil_to_tensor_bhwc(img))
-                # Extract real files without extensions → Precisely clean system extensions
-                raw_name = os.path.splitext(os.path.basename(abs_path))[0]
-                clean_name = _clean_filename(raw_name, keep_legitimate_brackets)
-                filenames.append(clean_name)
+                pil = Image.open(abs_path)
+                images.append(_pil_to_tensor_bhwc(pil))
+                names.append(_name_for_output(abs_path, filename_handling))
             except Exception as e:
                 print(f"[vsLinx_LoadSelectedImagesList] skip {abs_path}: {e}")
 
@@ -168,10 +161,16 @@ class VSLinx_LoadSelectedImagesList:
             _fail_if_needed(0, rels, fail_if_empty, "Load (Multiple) Images (List)")
             return ([], [])
 
-        return (images, filenames)
+        return (images, names)
 
 class VSLinx_LoadSelectedImagesBatch:
-    DESCRIPTION = "Provides a simple node with a “Select Images” button that lets you choose one or multiple images. After selection, the images are uploaded to your input folder in ComfyUI (the same behavior as the default Load Image node). The node also includes a preview of the selected images. The images are returned as a batch, allowing downstream nodes to process them together. Extra: Output filenames without extension."
+    """
+    Returns a batched IMAGE tensor (B,H,W,3) and a single comma-separated
+    STRING of filenames (without extension) per 'filename_handling'.
+    All images are resized to the first image's size for a valid batch.
+    """
+    DESCRIPTION = ("Provides a simple node with a “Select Images” button for multiple selection. "
+                   "Returns an image batch and a comma-separated filenames string (no extension).")
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -183,10 +182,8 @@ class VSLinx_LoadSelectedImagesBatch:
                     "placeholder": "Filled by the 'Select images' button (JSON array)."
                 }),
                 "fail_if_empty": ("BOOLEAN", {"default": True}),
+                "filename_handling": (FILENAME_HANDLING_OPTIONS, {"default": "full filename"}),
             },
-            "optional": {
-                "keep_legitimate_brackets": ("BOOLEAN", {"default": True}),  # New: Retain valid parentheses?
-            }
         }
 
     RETURN_TYPES = ("IMAGE", "STRING")
@@ -194,7 +191,13 @@ class VSLinx_LoadSelectedImagesBatch:
     FUNCTION = "load_batch"
     CATEGORY = "vsLinx/image"
 
-    def load_batch(self, selected_paths: str = "", fail_if_empty: bool = True, keep_legitimate_brackets: bool = True, **kwargs):
+    def load_batch(
+        self,
+        selected_paths: str = "",
+        fail_if_empty: bool = True,
+        filename_handling: str = "full filename",
+        **kwargs
+    ):
         if not selected_paths:
             selected_paths = kwargs.get("selected_paths", "")
 
@@ -210,14 +213,11 @@ class VSLinx_LoadSelectedImagesBatch:
         _fail_if_needed(len(existing), missing, fail_if_empty, "Load (Multiple) Images (Batch)")
 
         pil_images: List[Image.Image] = []
-        filenames = []
+        names: List[str] = []
         for abs_path in existing:
             try:
                 pil_images.append(Image.open(abs_path))
-                # Extract real files without extensions → Precisely clean system extensions
-                raw_name = os.path.splitext(os.path.basename(abs_path))[0]
-                clean_name = _clean_filename(raw_name, keep_legitimate_brackets)
-                filenames.append(clean_name)
+                names.append(_name_for_output(abs_path, filename_handling))
             except Exception as e:
                 print(f"[vsLinx_LoadSelectedImagesBatch] skip {abs_path}: {e}")
 
@@ -232,18 +232,14 @@ class VSLinx_LoadSelectedImagesBatch:
         tensors = [_pil_to_tensor_bhwc(im) for im in pil_images]
         batch = torch.cat(tensors, dim=0)
 
-        filenames_str = ", ".join(filenames)
-
+        filenames_str = ", ".join(names)
         return (batch, filenames_str)
 
 NODE_CLASS_MAPPINGS = {
     "vsLinx_LoadSelectedImagesList": VSLinx_LoadSelectedImagesList,
     "vsLinx_LoadSelectedImagesBatch": VSLinx_LoadSelectedImagesBatch,
 }
-
 NODE_DISPLAY_NAME_MAPPINGS = {
     "vsLinx_LoadSelectedImagesList": "Load (Multiple) Images (List)",
     "vsLinx_LoadSelectedImagesBatch": "Load (Multiple) Images (Batch)",
 }
-
-__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']

--- a/nodes/multi_image_select.py
+++ b/nodes/multi_image_select.py
@@ -1,4 +1,6 @@
-import os, json
+import os
+import json
+import re
 from typing import List, Tuple
 import numpy as np
 from PIL import Image, ImageOps
@@ -45,22 +47,58 @@ def _parse_paths(s: str) -> List[str]:
 
 def _resolve_existing(rels: List[str]) -> Tuple[List[str], List[str]]:
     """
-    Resolve relative paths against the input root, clamp to root,
-    and keep only files that exist and have known image extensions.
-    Returns (existing_abs_paths, missing_rel_paths).
+    Core Optimization: Prioritize using the actual file paths from the input directory over temporary paths passed from the frontend.
     """
     root = os.path.abspath(_input_root()) + os.sep
     existing: List[str] = []
     missing: List[str] = []
+    
+    # First, retrieve all valid images in the input directory (for matching actual paths).
+    input_files = {}
+    for file in os.listdir(root):
+        if os.path.splitext(file)[1].lower() in IMG_EXTS:
+            # Key: filename without extension (for matching), Value: actual absolute path
+            input_files[os.path.splitext(file)[0].lower()] = os.path.join(root, file)
+
     for rel in rels:
-        ext_ok = os.path.splitext(rel)[1].lower() in IMG_EXTS
-        abs_path = os.path.abspath(os.path.join(root, rel))
-        in_root = abs_path.startswith(root)
-        if not (ext_ok and in_root and os.path.isfile(abs_path)):
+        # Extract the filename (without extension) from the path passed to the frontend, used to match the actual file in the input directory.
+        rel_basename = os.path.basename(rel)
+        rel_name_noext = os.path.splitext(rel_basename)[0].lower()
+        # Name after the cleaning system suffix (for fuzzy matching)
+        rel_name_clean = re.sub(r'\s*\(\d+\)$', '', rel_name_noext)
+
+        # Prioritize matching actual files in the input directory
+        real_abs_path = None
+        if rel_name_noext in input_files:
+            real_abs_path = input_files[rel_name_noext]
+        elif rel_name_clean in input_files:
+            real_abs_path = input_files[rel_name_clean]
+        else:
+            # Fallback: Resolve according to the original logic.
+            abs_path = os.path.abspath(os.path.join(root, rel))
+            ext_ok = os.path.splitext(rel)[1].lower() in IMG_EXTS
+            in_root = abs_path.startswith(root)
+            if ext_ok and in_root and os.path.isfile(abs_path):
+                real_abs_path = abs_path
+
+        if real_abs_path:
+            existing.append(real_abs_path)
+        else:
             missing.append(rel)
-            continue
-        existing.append(abs_path)
     return existing, missing
+
+def _clean_filename(filename: str, keep_legitimate_brackets: bool = True) -> str:
+    """
+    Precision Cleaning: Removes only the automatically added "(number)" suffix, preserving valid parentheses.
+    - keep_legitimate_brackets=True：Retain as test(1).png → test(1), only clean up test (1).png → test
+    """
+    if keep_legitimate_brackets:
+        # The regular expression only matches system suffixes ending with "space + (digit)" (e.g., "2 (2)" → "2", "test(1)" → "test(1)").
+        clean_name = re.sub(r'\s+\(\d+\)$', '', filename)
+    else:
+        # Compatibility Mode: Remove all trailing (numbers) (Not recommended)
+        clean_name = re.sub(r'\(\d+\)$', '', filename)
+    return clean_name
 
 def _fail_if_needed(existing_count: int, missing: List[str], fail_if_empty: bool, node_name: str):
     if fail_if_empty and existing_count == 0:
@@ -75,11 +113,7 @@ def _fail_if_needed(existing_count: int, missing: List[str], fail_if_empty: bool
         )
 
 class VSLinx_LoadSelectedImagesList:
-    """
-    Reads files listed in `selected_paths` (relative to ComfyUI input dir)
-    and outputs an IMAGE **list** where each item is BHWC with B=1.
-    """
-    DESCRIPTION = "Provides a simple node with a “Select Images” button that lets you choose one or multiple images. After selection, the images are uploaded to your input folder in ComfyUI (the same behavior as the default Load Image node). The node also includes a preview of the selected images. The images are returned as an image list, allowing downstream nodes to process them one after another."
+    DESCRIPTION = "Provides a simple node with a “Select Images” button that lets you choose one or multiple images. After selection, the images are uploaded to your input folder in ComfyUI (the same behavior as the default Load Image node). The node also includes a preview of the selected images. The images are returned as an image list, allowing downstream nodes to process them one after another. Extra: Output filenames without extension."
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -92,15 +126,18 @@ class VSLinx_LoadSelectedImagesList:
                 }),
                 "fail_if_empty": ("BOOLEAN", {"default": True}),
             },
+            "optional": {
+                "keep_legitimate_brackets": ("BOOLEAN", {"default": True}),  # New: Retain valid parentheses?
+            }
         }
 
-    RETURN_TYPES = ("IMAGE",)
-    RETURN_NAMES = ("images",)
-    OUTPUT_IS_LIST = (True,)
+    RETURN_TYPES = ("IMAGE", "STRING")
+    RETURN_NAMES = ("images", "filenames")
+    OUTPUT_IS_LIST = (True, True)
     FUNCTION = "load"
     CATEGORY = "vsLinx/image"
 
-    def load(self, selected_paths: str = "", fail_if_empty: bool = True, **kwargs):
+    def load(self, selected_paths: str = "", fail_if_empty: bool = True, keep_legitimate_brackets: bool = True, **kwargs):
         if not selected_paths:
             selected_paths = kwargs.get("selected_paths", "")
 
@@ -109,32 +146,32 @@ class VSLinx_LoadSelectedImagesList:
 
         if not rels:
             _fail_if_needed(0, [], fail_if_empty, "Load (Multiple) Images (List)")
-            return ([],)
+            return ([], [])
 
         existing, missing = _resolve_existing(rels)
         _fail_if_needed(len(existing), missing, fail_if_empty, "Load (Multiple) Images (List)")
 
         images = []
+        filenames = []
         for abs_path in existing:
             try:
                 img = Image.open(abs_path)
                 images.append(_pil_to_tensor_bhwc(img))
+                # Extract real files without extensions → Precisely clean system extensions
+                raw_name = os.path.splitext(os.path.basename(abs_path))[0]
+                clean_name = _clean_filename(raw_name, keep_legitimate_brackets)
+                filenames.append(clean_name)
             except Exception as e:
                 print(f"[vsLinx_LoadSelectedImagesList] skip {abs_path}: {e}")
 
         if not images:
             _fail_if_needed(0, rels, fail_if_empty, "Load (Multiple) Images (List)")
-            return ([],)
+            return ([], [])
 
-        return (images,)
+        return (images, filenames)
 
 class VSLinx_LoadSelectedImagesBatch:
-    """
-    Same as above, but returns a single **batched** IMAGE tensor (B, H, W, 3).
-    All images are resized to the first image's size to ensure a valid batch.
-    """
-    DESCRIPTION = "Provides a simple node with a “Select Images” button that lets you choose one or multiple images. After selection, the images are uploaded to your input folder in ComfyUI (the same behavior as the default Load Image node). The node also includes a preview of the selected images. The images are returned as a batch, allowing downstream nodes to process them together."
-
+    DESCRIPTION = "Provides a simple node with a “Select Images” button that lets you choose one or multiple images. After selection, the images are uploaded to your input folder in ComfyUI (the same behavior as the default Load Image node). The node also includes a preview of the selected images. The images are returned as a batch, allowing downstream nodes to process them together. Extra: Output filenames without extension."
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -147,14 +184,17 @@ class VSLinx_LoadSelectedImagesBatch:
                 }),
                 "fail_if_empty": ("BOOLEAN", {"default": True}),
             },
+            "optional": {
+                "keep_legitimate_brackets": ("BOOLEAN", {"default": True}),  # New: Retain valid parentheses?
+            }
         }
 
-    RETURN_TYPES = ("IMAGE",)
-    RETURN_NAMES = ("images",)
+    RETURN_TYPES = ("IMAGE", "STRING")
+    RETURN_NAMES = ("images", "filenames")
     FUNCTION = "load_batch"
     CATEGORY = "vsLinx/image"
 
-    def load_batch(self, selected_paths: str = "", fail_if_empty: bool = True, **kwargs):
+    def load_batch(self, selected_paths: str = "", fail_if_empty: bool = True, keep_legitimate_brackets: bool = True, **kwargs):
         if not selected_paths:
             selected_paths = kwargs.get("selected_paths", "")
 
@@ -164,22 +204,27 @@ class VSLinx_LoadSelectedImagesBatch:
         if not rels:
             _fail_if_needed(0, [], fail_if_empty, "Load (Multiple) Images (Batch)")
             empty = torch.zeros((0, 64, 64, 3), dtype=torch.float32)
-            return (empty,)
+            return (empty, "")
 
         existing, missing = _resolve_existing(rels)
         _fail_if_needed(len(existing), missing, fail_if_empty, "Load (Multiple) Images (Batch)")
 
         pil_images: List[Image.Image] = []
+        filenames = []
         for abs_path in existing:
             try:
                 pil_images.append(Image.open(abs_path))
+                # Extract real files without extensions → Precisely clean system extensions
+                raw_name = os.path.splitext(os.path.basename(abs_path))[0]
+                clean_name = _clean_filename(raw_name, keep_legitimate_brackets)
+                filenames.append(clean_name)
             except Exception as e:
                 print(f"[vsLinx_LoadSelectedImagesBatch] skip {abs_path}: {e}")
 
         if not pil_images:
             _fail_if_needed(0, rels, fail_if_empty, "Load (Multiple) Images (Batch)")
             empty = torch.zeros((0, 64, 64, 3), dtype=torch.float32)
-            return (empty,)
+            return (empty, "")
 
         W0, H0 = pil_images[0].size
         pil_images = [_resize_like(im, W0, H0) for im in pil_images]
@@ -187,13 +232,18 @@ class VSLinx_LoadSelectedImagesBatch:
         tensors = [_pil_to_tensor_bhwc(im) for im in pil_images]
         batch = torch.cat(tensors, dim=0)
 
-        return (batch,)
+        filenames_str = ", ".join(filenames)
+
+        return (batch, filenames_str)
 
 NODE_CLASS_MAPPINGS = {
     "vsLinx_LoadSelectedImagesList": VSLinx_LoadSelectedImagesList,
     "vsLinx_LoadSelectedImagesBatch": VSLinx_LoadSelectedImagesBatch,
 }
+
 NODE_DISPLAY_NAME_MAPPINGS = {
     "vsLinx_LoadSelectedImagesList": "Load (Multiple) Images (List)",
     "vsLinx_LoadSelectedImagesBatch": "Load (Multiple) Images (Batch)",
 }
+
+__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']

--- a/nodes/multi_image_select.py
+++ b/nodes/multi_image_select.py
@@ -74,8 +74,6 @@ def _fail_if_needed(existing_count: int, missing: List[str], fail_if_empty: bool
             f"{node_name}: No valid images found. They may have been moved or deleted from the input folder.{hint}"
         )
 
-# ------------------ filename handling ------------------
-
 FILENAME_HANDLING_OPTIONS = ("full filename", "deduped filename")
 
 def _name_for_output(abs_path: str, handling: str) -> str:
@@ -89,13 +87,9 @@ def _name_for_output(abs_path: str, handling: str) -> str:
     stem, _ext = os.path.splitext(base)
 
     if handling == "deduped filename":
-        # remove only " space + (number)" at the end, e.g. 'cat (2)' -> 'cat'
         stem = re.sub(r"\s+\(\d+\)$", "", stem)
 
-    # default or 'full filename' -> unchanged stem
     return stem
-
-# -------------------------------------------------------
 
 class VSLinx_LoadSelectedImagesList:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: load multiple images via a multi-select dialog with preview; images upload instantly to the input folder and can be output as a list or a batch. Includes boolean AND/OR plus a boolean flip for easy branching, and nodes that bypass or mute other nodes based on a boolean value. Also includes “Fit Image into BBox Mask” to precisely fit/place an image into a mask region’s bounding box—ideal for compositing poses, objects, or partial elements—while preserving aspect ratio and offering alignment options. Adds a bridge from rgthree Power LoRA Loader to the image saver to store LoRA info in metadata, plus settings to show previews of all models & LoRAs across all model loaders - compatible with rgthree's subdirectory view."
-version = "1.6.0"
+version = "1.6.1"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/VSLinx_LoadSelectedImagesBatch.md
+++ b/web/docs/VSLinx_LoadSelectedImagesBatch.md
@@ -1,4 +1,4 @@
-This node provides a “Select Images” button to choose one or multiple images and upload them to your ``input`` folder (same behavior as the default **Load Image** node). It includes a tiled preview and a fullscreen preview per image. <b>The images are returned as a single batched tensor, allowing downstream nodes to process them together.</b>
+This node provides a “Select Images” button to choose one or multiple images and upload them to your ``input`` folder (same behavior as the default **Load Image** node). It includes a tiled preview and a fullscreen preview per image. <b>The images are returned as a batch</b>, allowing downstream nodes to process them together while the <b>filenames are returned as a string of all filenames seperated by a comma</b>.
 
 This node does the following:
 - Accepts paths from the “Select Images” UI as a JSON array or newline-separated list in ``selected_paths``.
@@ -8,17 +8,21 @@ This node does the following:
 - Resizes **all** images to the first image’s size to form a valid batch.
 - Stacks them into a single tensor with shape ``(B, H, W, 3)`` (BHWC).
 - Optionally returns an **empty** batch (``(0, 64, 64, 3)``) if nothing valid is found and ``fail_if_empty`` is false; otherwise raises an error.
+- Returns filenames without their extension as a comma seperated string with ``filename_handling``-property to dedupe duplicate filenames if needed.
 
 Parameters:
 | Parameter | Type | Description |
 | -------- | ---- | ----------- |
 | selected_paths | STRING (multiline) | Paths filled by the **Select Images** button (JSON array or newline-separated). Paths are relative to the ``input`` folder. Duplicates are removed. |
 | fail_if_empty | BOOLEAN | If true, throws an error when no valid images are found (e.g., files moved/deleted). |
+| filename_handling | ENUM | If set to ``full filename`` the filenames output returns the full filenames (without the extension), setting it to ``deduped filename`` will remove automatically added `` (n)`` from duplicate filenames in your input folder before returning it |
+
 
 Outputs:
 | Parameter | Type | Description |
 | -------- | ---- | ----------- |
 | images | IMAGE (batch) | A single batched tensor with shape ``(B, H, W, 3)`` (BHWC). All images are resized to match the first image’s dimensions. |
+| filenames | STRING | A single string of comma seperated filenames without their extension |
 
 Notes:
 - Files are clamped to the ``input`` root for safety; anything outside is ignored.

--- a/web/docs/VSLinx_LoadSelectedImagesList.md
+++ b/web/docs/VSLinx_LoadSelectedImagesList.md
@@ -1,4 +1,4 @@
-This node provides a “Select Images” button to choose one or multiple images and upload them to your ``input`` folder (same behavior as the default **Load Image** node). It includes a tiled preview and a fullscreen preview per image. <b>The images are returned as an image list, allowing downstream nodes to process them one after another.</b>
+This node provides a “Select Images” button to choose one or multiple images and upload them to your ``input`` folder (same behavior as the default **Load Image** node). It includes a tiled preview and a fullscreen preview per image. <b>The images and filenames are returned as a list</b>, allowing downstream nodes to process them one after another.
 
 This node does the following:
 - Accepts paths from the “Select Images” UI as a JSON array or newline-separated list in ``selected_paths``.
@@ -7,17 +7,20 @@ This node does the following:
 - Loads each image, corrects EXIF orientation, converts to RGB if needed, and turns it into a BHWC tensor with B=1.
 - Returns a **list** of images (each item: shape ``(1, H, W, 3)``).  
 - Optionally raises an error if no valid images are found (``fail_if_empty``).
+- Returns filenames without their extension as a list alongside the images with a ``filename_handling``-property to dedupe duplicate filenames if needed.
 
 Parameters:
 | Parameter | Type | Description |
 | -------- | ---- | ----------- |
 | selected_paths | STRING (multiline) | Paths filled by the **Select Images** button (JSON array or newline-separated). Paths are relative to the ``input`` folder. Duplicates are removed. |
 | fail_if_empty | BOOLEAN | If true, throws an error when no valid images are found (e.g., files moved/deleted). |
+| filename_handling | ENUM | If set to ``full filename`` the filenames output returns the full filenames (without the extension), setting it to ``deduped filename`` will remove automatically added `` (n)`` from duplicate filenames in your input folder before returning it |
 
 Outputs:
 | Parameter | Type | Description |
 | -------- | ---- | ----------- |
 | images | IMAGE (list) | A list of images; each element is a tensor with shape ``(1, H, W, 3)`` (BHWC with B=1). |
+| filenames | STRING (list) | A list of strings; each filename is without their extension |
 
 Notes:
 - Files are clamped to the ``input`` root for safety; anything outside is ignored.


### PR DESCRIPTION
"I've added a small feature to multi_image_select using AI, which enables output filename generation. It prevents duplicate filenames in the input folder by appending parentheses. Automatic cleanup is also configured to facilitate batch processing, making it easier to save modified files while preserving their original filenames. I'm not a developer, but the feature has been tested successfully. Please review the addition. Thank you."