### PR TITLE
feat(Load last generated Image): Better version of the comfyui node

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ his node upscales an image using a selected <b>upscale model</b> and then resize
 <img width="1420" height="602" alt="Image" src="https://github.com/user-attachments/assets/d1845c2e-0d8b-480d-8177-7799f8259b2a" />
 
 #### Load Last Generated Image
-This node loads an image from your ``output`` folder and serves as a replacement for ComfyUI's built-in **LoadImageOutput** node. A dropdown lists all images sorted by newest first, so the most recent generation is always at the top. When ``auto_refresh`` is enabled, the node automatically picks up newly generated images after each workflow execution — but only when a new file actually appeared, so your current selection stays untouched otherwise.
+This node loads an image from your ``output`` folder and serves as a replacement for ComfyUI's built-in **LoadImageOutput** node. A dropdown lists all images sorted by newest first, so the most recent generation is always at the top. When ``Auto refresh after generation`` is enabled, the node automatically picks up newly generated images after each workflow execution — but only when a new file actually appeared, so your current selection stays untouched otherwise.
 
 The node supports the **MaskEditor** (right-click → "Open in MaskEditor"). Painted masks are preserved across workflow executions, tab switches, and page reloads. If no image is available or the selected file was deleted, the node outputs a 512×512 black image to prevent blocking your workflow.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Note that a batch is a tensor of the same shape, if your images have different h
 his node upscales an image using a selected <b>upscale model</b> and then resizes the result to a target scale factor. <b>Upscale models typically operate at a fixed scale (e.g. 2× or 4×).</b> This node first runs the model at its native scale, then applies a final resize step to match your requested factor. Minimum is 0.1 scale while the maximum is 8.0 scale.
 <img width="1420" height="602" alt="Image" src="https://github.com/user-attachments/assets/d1845c2e-0d8b-480d-8177-7799f8259b2a" />
 
+#### Load Last Generated Image
+This node loads an image from your ``output`` folder and serves as a replacement for ComfyUI's built-in **LoadImageOutput** node. A dropdown lists all images sorted by newest first, so the most recent generation is always at the top. When ``auto_refresh`` is enabled, the node automatically picks up newly generated images after each workflow execution — but only when a new file actually appeared, so your current selection stays untouched otherwise.
+
+The node supports the **MaskEditor** (right-click → "Open in MaskEditor"). Painted masks are preserved across workflow executions, tab switches, and page reloads. If no image is available or the selected file was deleted, the node outputs a 512×512 black image to prevent blocking your workflow.
+
+A ``include_subfolders`` property (right-click → Properties) controls whether images from subfolders inside the ``output`` directory are included in the dropdown.
+
 ### Boolean
 #### Boolean AND Operator
 Provides a node with 2 boolean inputs. Outputs True only if both inputs are True. Otherwise returns False. <br>
@@ -119,6 +126,9 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.7.0
+- added new ``Load Last Generated Image``-Node as a replacement for ComfyUI's built-in **LoadImageOutput** node. Provides a dropdown of all images in the output folder (newest first), auto-refresh after generation, a manual refresh button, a file upload button, and full MaskEditor support with mask persistence across executions, tab switches, and page reloads. Falls back to a 512×512 black image when no image is available.
+
 ### v.1.6.1
 - added filename export for ``Load (Multiple) Images (List)`` and ``Load (Multiple) Images (Batch)`` with a node-property to also dedupe the filename to remove `` (number)`` from the name in case of a duplicate filename 
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This node loads an image from your ``output`` folder and serves as a replacement
 
 The node supports the **MaskEditor** (right-click → "Open in MaskEditor"). Painted masks are preserved across workflow executions, tab switches, and page reloads. If no image is available or the selected file was deleted, the node outputs a 512×512 black image to prevent blocking your workflow.
 
-A ``include_subfolders`` property (right-click → Properties) controls whether images from subfolders inside the ``output`` directory are included in the dropdown.
+A ``include_subfolders`` property (right-click → Properties) controls whether images from subfolders inside the ``output`` directory are included in the dropdown and refresh functions.
 
 ### Boolean
 #### Boolean AND Operator

--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,8 @@ node_list = [
     "inpaint_helper",
     "lora_save_helper",
     "impact_multiline_wildcard_text",
-    "upscale_by_factor_with_model"
+    "upscale_by_factor_with_model",
+    "load_last_generated"
 ]
 
 NODE_CLASS_MAPPINGS = {}

--- a/nodes/load_last_generated.py
+++ b/nodes/load_last_generated.py
@@ -1,0 +1,202 @@
+import os
+import hashlib
+import re
+import numpy as np
+import torch
+from PIL import Image, ImageOps, ImageSequence
+
+import folder_paths
+import node_helpers
+from aiohttp import web
+from server import PromptServer
+
+_IMG_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif", ".tiff", ".tif"}
+_ANNOTATION_RE = re.compile(r"\s*\[[^\]]+\]\s*$")
+
+
+def _strip_annotation(value: str) -> str:
+    """Strip ComfyUI folder annotation like ' [output]' from a widget value."""
+    return _ANNOTATION_RE.sub("", value or "").strip()
+
+
+def _list_output_images(include_subfolders=True):
+    """List image files in the output directory, sorted by mtime descending (newest first)."""
+    output_dir = folder_paths.get_output_directory()
+    results = []
+
+    if include_subfolders:
+        for root, _dirs, files in os.walk(output_dir):
+            for f in files:
+                if os.path.splitext(f)[1].lower() not in _IMG_EXTS:
+                    continue
+                full = os.path.join(root, f)
+                if not os.path.isfile(full):
+                    continue
+                rel = os.path.relpath(full, output_dir).replace("\\", "/")
+                if rel.startswith("./"):
+                    rel = rel[2:]
+                try:
+                    mtime = os.path.getmtime(full)
+                except Exception:
+                    mtime = 0
+                results.append((rel, mtime))
+    else:
+        try:
+            for f in os.listdir(output_dir):
+                full = os.path.join(output_dir, f)
+                if os.path.isfile(full) and os.path.splitext(f)[1].lower() in _IMG_EXTS:
+                    try:
+                        mtime = os.path.getmtime(full)
+                    except Exception:
+                        mtime = 0
+                    results.append((f, mtime))
+        except Exception:
+            pass
+
+    results.sort(key=lambda x: x[1], reverse=True)
+    return [r[0] for r in results]
+
+
+def _resolve_image_path(image: str) -> str:
+    """Resolve an image widget value to an absolute file path.
+
+    Handles ComfyUI folder annotations (e.g. 'file.png [output]') via
+    folder_paths.get_annotated_filepath.  Clipspace paths (from the
+    MaskEditor) live in the input directory; everything else defaults
+    to the output directory.
+    """
+    clean = _strip_annotation(image)
+    if clean.startswith("clipspace/"):
+        return folder_paths.get_annotated_filepath(image, default_dir=folder_paths.get_input_directory())
+    return folder_paths.get_annotated_filepath(image, default_dir=folder_paths.get_output_directory())
+
+
+@PromptServer.instance.routes.get("/vslinx/output_images_list")
+async def vslinx_output_images_list(request: web.Request):
+    include_sub = request.rel_url.query.get("include_subfolders", "true").lower() in ("true", "1", "yes")
+    try:
+        files = _list_output_images(include_sub)
+        return web.json_response({"files": files})
+    except Exception as e:
+        return web.json_response({"error": str(e), "files": []}, status=500)
+
+
+def _make_black_image():
+    """Create a 512x512 black image tensor and empty mask."""
+    image = torch.zeros((1, 512, 512, 3), dtype=torch.float32)
+    mask = torch.zeros((1, 512, 512), dtype=torch.float32)
+    return (image, mask)
+
+
+class VSLinx_LoadLastGeneratedImage:
+    CATEGORY = "vsLinx/image"
+    FUNCTION = "load_image"
+    RETURN_TYPES = ("IMAGE", "MASK")
+    RETURN_NAMES = ("image", "mask")
+    DESCRIPTION = (
+        "Load the last generated image from the output folder. "
+        "Supports auto-refresh after generation, manual refresh, file upload, "
+        "and subfolder inclusion. Falls back to a black 512x512 image if no image is available."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("STRING", {"default": ""}),
+                "auto_refresh": ("BOOLEAN", {"default": True}),
+            },
+        }
+
+    def load_image(self, image, auto_refresh):
+        clean = _strip_annotation(image)
+
+        if not clean or clean == "(None)":
+            files = _list_output_images(include_subfolders=True)
+            if files:
+                image = files[0]
+            else:
+                return _make_black_image()
+
+        # Pass the original value so folder annotations like [temp], [input],
+        # [output] are resolved by ComfyUI (e.g. clipspace painted masks).
+        image_path = _resolve_image_path(image)
+
+        if not os.path.isfile(image_path):
+            return _make_black_image()
+
+        img = node_helpers.pillow(Image.open, image_path)
+        output_images = []
+        output_masks = []
+        w, h = None, None
+
+        for i in ImageSequence.Iterator(img):
+            i = node_helpers.pillow(ImageOps.exif_transpose, i)
+
+            if i.mode == "I":
+                i = i.point(lambda x: x * (1 / 255))
+            frame = i.convert("RGB")
+
+            if len(output_images) == 0:
+                w = frame.size[0]
+                h = frame.size[1]
+
+            if frame.size[0] != w or frame.size[1] != h:
+                continue
+
+            arr = np.array(frame).astype(np.float32) / 255.0
+            tensor = torch.from_numpy(arr)[None,]
+
+            if "A" in i.getbands():
+                mask = np.array(i.getchannel("A")).astype(np.float32) / 255.0
+                mask = 1.0 - torch.from_numpy(mask)
+            elif i.mode == "P" and "transparency" in i.info:
+                mask = np.array(i.convert("RGBA").getchannel("A")).astype(np.float32) / 255.0
+                mask = 1.0 - torch.from_numpy(mask)
+            else:
+                mask = torch.zeros((h, w), dtype=torch.float32, device="cpu")
+
+            output_images.append(tensor)
+            output_masks.append(mask.unsqueeze(0))
+
+            if img.format == "MPO":
+                break
+
+        if not output_images:
+            return _make_black_image()
+
+        if len(output_images) > 1:
+            return (torch.cat(output_images, dim=0), torch.cat(output_masks, dim=0))
+        return (output_images[0], output_masks[0])
+
+    @classmethod
+    def IS_CHANGED(cls, image, auto_refresh):
+        clean = _strip_annotation(image)
+        if not clean or clean == "(None)":
+            return float("nan")
+
+        image_path = _resolve_image_path(image)
+
+        if not os.path.isfile(image_path):
+            return float("nan")
+
+        try:
+            m = hashlib.sha256()
+            with open(image_path, "rb") as f:
+                m.update(f.read())
+            return m.digest().hex()
+        except Exception:
+            return float("nan")
+
+    @classmethod
+    def VALIDATE_INPUTS(cls, image, auto_refresh):
+        return True
+
+
+NODE_CLASS_MAPPINGS = {
+    "vsLinx_LoadLastGeneratedImage": VSLinx_LoadLastGeneratedImage,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "vsLinx_LoadLastGeneratedImage": "Load Last Generated Image",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: load multiple images via a multi-select dialog with preview; images upload instantly to the input folder and can be output as a list or a batch. Includes boolean AND/OR plus a boolean flip for easy branching, and nodes that bypass or mute other nodes based on a boolean value. Also includes “Fit Image into BBox Mask” to precisely fit/place an image into a mask region’s bounding box—ideal for compositing poses, objects, or partial elements—while preserving aspect ratio and offering alignment options. Adds a bridge from rgthree Power LoRA Loader to the image saver to store LoRA info in metadata, plus settings to show previews of all models & LoRAs across all model loaders - compatible with rgthree's subdirectory view."
-version = "1.6.1"
+version = "1.7.0"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/vsLinx_LoadLastGeneratedImage.md
+++ b/web/docs/vsLinx_LoadLastGeneratedImage.md
@@ -1,0 +1,41 @@
+This node loads an image from the ``output`` folder via a dropdown, with the newest image pre-selected. It is designed as a replacement for ComfyUI's built-in **LoadImageOutput** node. It supports <b>auto-refresh after generation</b>, so it automatically picks up newly generated images without manual interaction. The node also supports the <b>MaskEditor</b> (right-click → "Open in MaskEditor"), and painted masks are preserved across workflow executions and tab switches. If no image is available, the node falls back to a <b>512×512 black image</b> to prevent blocking the workflow.
+
+This node does the following:
+- Lists all images in the ``output`` folder (optionally including subfolders), sorted by modification time (newest first).
+- Shows a dropdown to select any image from the list, with a live preview below the widgets.
+- When ``Auto refresh after generation`` is enabled, automatically detects newly generated images after workflow execution and selects them. If no new image appeared, the current selection (and any painted mask) is preserved.
+- Supports the MaskEditor: painted masks are saved to ``input/clipspace/`` by ComfyUI's MaskEditor. The node detects this and loads the masked image as both the preview and the source for the ``mask`` output.
+- Loads the selected image, corrects EXIF orientation, converts to RGB, and extracts the alpha channel as a mask (if present). Images with transparency (RGBA or palette-based) produce an inverted alpha mask; images without alpha produce an empty (all-zero) mask.
+- Falls back to a 512×512 black image with an empty mask when no valid image is found or the file is missing.
+
+Parameters:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| image | COMBO (UI-only) | Dropdown listing images from the ``output`` folder, sorted newest-first. This widget is not sent to the backend; it controls the hidden ``image`` widget. |
+| Auto refresh after generation | BOOLEAN | When true, the node automatically updates the dropdown and selects the newest image after each workflow execution — but only if a genuinely new file appeared. Default: ``true``. |
+
+Buttons:
+| Button | Description |
+| -------- | ----------- |
+| Refresh | Re-scans the output folder and selects the newest image. |
+| Choose file to upload | Opens a file picker to upload an image into the ``output`` folder, then selects it. |
+
+Outputs:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| image | IMAGE | The loaded image as a float32 tensor ``(1, H, W, 3)`` (RGB, 0–1 range). When a painted mask exists, this is the original image from clipspace (without the mask overlay). |
+| mask | MASK | A float32 tensor ``(1, H, W)``. Derived from the alpha channel (inverted) if the image has transparency, or from the MaskEditor's painted mask. All-zero if neither exists. |
+
+Node Properties (right-click → Properties):
+| Property | Type | Default | Description |
+| -------- | ---- | ------- | ----------- |
+| include_subfolders | BOOLEAN | true | When true, the dropdown lists images from all subfolders inside the ``output`` directory. When false, only top-level files are shown. Changing this re-scans and selects the newest image. |
+
+Notes:
+- The dropdown always shows ``output``-folder images. When you paint a mask via the MaskEditor, the masked image is saved to ``input/clipspace/`` by ComfyUI internally. The node detects this, updates the hidden ``image`` widget to point at the clipspace file, and shows the masked preview — but the dropdown still displays the original output image.
+- Painted masks are preserved across workflow executions (when no new file is generated), tab switches, and page reloads. The hidden ``image`` widget stores the full annotated path (e.g. ``clipspace/clipspace-painted-masked-xxx.png [input]``) which is serialized with the workflow.
+- Auto-refresh works by snapshotting the newest file before execution starts. After execution completes, it compares the new file list — only if a different file now sits at position 0 does it switch selection (and clear any painted mask). If no new file appeared, the current selection and mask are untouched.
+- If the selected file no longer exists on disk (e.g. manually deleted), the node falls back to a 512×512 black image rather than erroring. This ensures downstream nodes always receive valid tensors.
+- Supported image formats: ``.png``, ``.jpg``/``.jpeg``, ``.webp``, ``.bmp``, ``.gif``, ``.tiff``/``.tif``.
+- The file list is fetched via a custom API endpoint (``GET /vslinx/output_images_list?include_subfolders=true|false``) to avoid blocking the UI on large output folders.
+- ``IS_CHANGED`` uses a SHA-256 hash of the file contents, so re-executions are skipped when the selected image hasn't changed on disk.

--- a/web/js/load_last_generated.js
+++ b/web/js/load_last_generated.js
@@ -1,0 +1,408 @@
+import { app } from "/scripts/app.js";
+import { api } from "/scripts/api.js";
+
+app.registerExtension({
+  name: "VSLinx.LoadLastGeneratedImage",
+
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData?.name !== "vsLinx_LoadLastGeneratedImage") return;
+
+    const hideWidget = (w) => {
+      if (!w) return;
+      w.hidden = true;
+      w.draw = () => {};
+      w.computeSize = () => [0, 0];
+    };
+
+    const getImageWidget = (node) => node.widgets?.find((w) => w.name === "image");
+    const getAutoRefreshWidget = (node) => node.widgets?.find((w) => w.name === "auto_refresh");
+
+    const stripAnnotation = (val) => (val || "").replace(/ \[[^\]]+\]$/, "").trim();
+    const annotate = (rel) => `${rel} [output]`;
+
+    const getAnnotationType = (val) => {
+      const m = (val || "").match(/ \[([^\]]+)\]$/);
+      return m ? m[1] : "output";
+    };
+
+    /* Build a /view URL for any image. */
+    const buildViewURL = (rel, type = "output") => {
+      const parts = (rel || "").split("/");
+      const filename = parts.pop();
+      const subfolder = parts.join("/");
+      const params = new URLSearchParams({ filename, type, subfolder });
+      return api.apiURL(`/view?${params.toString()}`);
+    };
+
+    /* Load a preview image into node.imgs. */
+    const loadPreview = async (node, rel, type = "output") => {
+      if (!rel || rel === "(None)") {
+        node.imgs = null;
+        node.setDirtyCanvas(true, true);
+        return;
+      }
+      try {
+        const url = buildViewURL(rel, type);
+        const img = new Image();
+        img.crossOrigin = "anonymous";
+        await new Promise((resolve, reject) => {
+          img.onload = resolve;
+          img.onerror = reject;
+          img.src = url + `&cb=${Date.now()}`;
+        });
+        node.imgs = [img];
+      } catch {
+        node.imgs = null;
+      }
+      node.setDirtyCanvas(true, true);
+    };
+
+    /* Load preview from the hidden image widget, auto-detecting type. */
+    const loadPreviewFromWidget = async (node) => {
+      const raw = getImageWidget(node)?.value || "";
+      const stripped = stripAnnotation(raw);
+      if (!stripped || stripped === "(None)") {
+        node.imgs = null;
+        node.setDirtyCanvas(true, true);
+        return;
+      }
+      const type = stripped.startsWith("clipspace/") ? "input" : getAnnotationType(raw);
+      await loadPreview(node, stripped, type);
+    };
+
+    /* Reconstruct node.images from the hidden image widget value. */
+    const reconstructNodeImages = (node) => {
+      const raw = getImageWidget(node)?.value || "";
+      const stripped = stripAnnotation(raw);
+      if (!stripped || stripped === "(None)") {
+        node.images = null;
+        return;
+      }
+      const type = stripped.startsWith("clipspace/") ? "input" : getAnnotationType(raw);
+      const parts = stripped.split("/");
+      const fname = parts.pop();
+      const subfolder = parts.join("/");
+      node.images = [{ filename: fname, subfolder, type }];
+    };
+
+    const fetchImageList = async (node) => {
+      const includeSub = node.properties?.include_subfolders !== false;
+      try {
+        const resp = await api.fetchApi(
+          `/vslinx/output_images_list?include_subfolders=${includeSub}`
+        );
+        const data = await resp.json();
+        return data.files || [];
+      } catch {
+        return [];
+      }
+    };
+
+    /* Select an output-folder image. Sets the hidden widget to
+       "rel [output]" and updates node.images + preview. */
+    const setSelection = (node, rel) => {
+      const imgWidget = getImageWidget(node);
+      if (!rel || rel === "(None)") {
+        if (imgWidget) imgWidget.value = "";
+        node.images = null;
+        node.imgs = null;
+        node.setDirtyCanvas(true, true);
+        return;
+      }
+      if (imgWidget) imgWidget.value = annotate(rel);
+      const parts = rel.split("/");
+      const filename = parts.pop();
+      const subfolder = parts.join("/");
+      node.images = [{ filename, subfolder, type: "output" }];
+      loadPreview(node, rel, "output");
+    };
+
+    /* Called when the MaskEditor saves a painted mask to input/clipspace.
+       The MaskEditor already updated imgWidget.value to the clipspace path.
+       We just need to update node.images and load the preview. */
+    const onMaskEditorSave = (node, value) => {
+      const stripped = stripAnnotation(value);
+      if (!stripped.startsWith("clipspace/")) return;
+
+      const parts = stripped.split("/");
+      const fname = parts.pop();
+      const subfolder = parts.join("/");
+      node.images = [{ filename: fname, subfolder, type: "input" }];
+      loadPreview(node, stripped, "input");
+    };
+
+    /* Refresh the dropdown file list (output folder only).
+       selectLatest=true picks the newest file; false keeps current selection. */
+    const refreshDropdown = async (node, selectLatest = false) => {
+      const files = await fetchImageList(node);
+      const combo = node._imageCombo;
+      if (!combo) return;
+
+      const prevValue = combo.value;
+      combo.options.values = files.length ? files : ["(None)"];
+
+      if (selectLatest && files.length) {
+        combo.value = files[0];
+        setSelection(node, files[0]);
+      } else if (!files.length) {
+        combo.value = "(None)";
+        setSelection(node, "");
+      } else if (!files.includes(prevValue)) {
+        combo.value = files[0];
+        setSelection(node, files[0]);
+      }
+
+      node.setDirtyCanvas(true, true);
+    };
+
+    /* ── onNodeCreated ── */
+    const origCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const r = origCreated?.apply(this, arguments);
+
+      /* _isRestoring starts true. For NEW nodes it is cleared in the RAF.
+         For RESTORED nodes it stays true through configure() (which applies
+         widgets_values and may trigger the combo callback), and is cleared
+         in onConfigure's setTimeout after we've restored from the hidden widget. */
+      this._isRestoring = true;
+
+      /* properties */
+      this.properties = this.properties || {};
+      if (typeof this.properties.include_subfolders === "undefined") {
+        this.addProperty?.("include_subfolders", true);
+        if (typeof this.properties.include_subfolders === "undefined") {
+          this.properties.include_subfolders = true;
+        }
+      }
+
+      /* hide raw STRING widget and tag it for the MaskEditor */
+      const imgWidget = getImageWidget(this);
+      if (imgWidget) {
+        imgWidget.options = imgWidget.options || {};
+        imgWidget.options.image_upload = true;
+        imgWidget.options.image_folder = "output";
+
+        const self = this;
+        imgWidget.callback = (value) => {
+          onMaskEditorSave(self, value);
+        };
+      }
+      hideWidget(imgWidget);
+
+      /* dropdown — ALWAYS shows output-folder images only */
+      const combo = this.addWidget(
+        "combo",
+        "select_image",
+        "(None)",
+        (value) => {
+          if (this._isRestoring) return;
+          if (!value || value === "(None)") {
+            setSelection(this, "");
+          } else {
+            setSelection(this, value);
+          }
+        },
+        { values: ["(None)"] }
+      );
+      combo.label = "image";
+      this._imageCombo = combo;
+
+      /* move auto_refresh widget right after the combo */
+      const autoRefreshW = getAutoRefreshWidget(this);
+      if (autoRefreshW) {
+        autoRefreshW.label = "Auto refresh after generation";
+        const idx = this.widgets.indexOf(autoRefreshW);
+        if (idx >= 0) {
+          this.widgets.splice(idx, 1);
+          this.widgets.push(autoRefreshW);
+        }
+      }
+
+      /* refresh button */
+      this.addWidget("button", "Refresh", null, () => {
+        refreshDropdown(this, true);
+      });
+
+      /* upload button */
+      this.addWidget("button", "Choose file to upload", null, () => {
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = "image/*";
+        input.style.display = "none";
+        document.body.appendChild(input);
+
+        input.addEventListener("change", async () => {
+          const file = input.files?.[0];
+          document.body.removeChild(input);
+          if (!file) return;
+
+          const form = new FormData();
+          form.append("image", file, file.name);
+          form.append("type", "output");
+
+          try {
+            const resp = await api.fetchApi("/upload/image", {
+              method: "POST",
+              body: form,
+            });
+            if (!resp.ok) {
+              console.error("[LoadLastGenerated] Upload failed", resp.status);
+              return;
+            }
+            const data = await resp.json();
+            const rel = data.subfolder ? `${data.subfolder}/${data.name}` : data.name;
+
+            await refreshDropdown(this, false);
+
+            combo.value = rel;
+            setSelection(this, rel);
+          } catch (e) {
+            console.error("[LoadLastGenerated] Upload error", e);
+          }
+        });
+
+        input.click();
+      });
+
+      /* ── auto-refresh after execution ── */
+      this._wasExecuting = false;
+      this._preExecLatest = null;
+
+      this._executionHandler = ({ detail }) => {
+        if (detail) {
+          if (!this._wasExecuting) {
+            this._wasExecuting = true;
+            this._preExecLatest = this._imageCombo?.options?.values?.[0] || null;
+          }
+        } else if (this._wasExecuting) {
+          this._wasExecuting = false;
+          const arw = getAutoRefreshWidget(this);
+          if (!arw?.value) return;
+
+          const preLatest = this._preExecLatest;
+
+          setTimeout(async () => {
+            const files = await fetchImageList(this);
+            const combo = this._imageCombo;
+            if (!combo) return;
+
+            combo.options.values = files.length ? files : ["(None)"];
+
+            const hasNewFile = files.length > 0 && files[0] !== preLatest;
+            if (hasNewFile) {
+              combo.value = files[0];
+              setSelection(this, files[0]);
+            }
+
+            this.setDirtyCanvas(true, true);
+          }, 300);
+        }
+      };
+      api.addEventListener("executing", this._executionHandler);
+
+      /* initial populate — only for genuinely new nodes */
+      this._skipInitialRefresh = false;
+      requestAnimationFrame(() => {
+        if (!this._skipInitialRefresh) {
+          this._isRestoring = false;
+          refreshDropdown(this, true);
+        }
+      });
+
+      return r;
+    };
+
+    /* ── cleanup ── */
+    const origRemoved = nodeType.prototype.onRemoved;
+    nodeType.prototype.onRemoved = function () {
+      if (this._executionHandler) {
+        api.removeEventListener("executing", this._executionHandler);
+      }
+      return origRemoved?.apply(this, arguments);
+    };
+
+    /* ── property changes ── */
+    const origOnPropertyChanged = nodeType.prototype.onPropertyChanged;
+    nodeType.prototype.onPropertyChanged = function (name) {
+      const r = origOnPropertyChanged?.apply(this, arguments);
+      if (name === "include_subfolders" && !this._isRestoring) {
+        refreshDropdown(this, true);
+      }
+      return r;
+    };
+
+    /* ── configure (load saved workflow / tab switch) ── */
+    const origConfigure = nodeType.prototype.onConfigure;
+    nodeType.prototype.onConfigure = function (...args) {
+      const r = origConfigure?.apply(this, args);
+
+      /* _isRestoring is already true from onNodeCreated — combo callback
+         is blocked. Prevent the RAF from running too. */
+      this._skipInitialRefresh = true;
+
+      this.properties = this.properties || {};
+      if (typeof this.properties.include_subfolders === "undefined") {
+        this.properties.include_subfolders = true;
+      }
+
+      setTimeout(() => {
+        /* NOW it's safe to allow combo callbacks again */
+        this._isRestoring = false;
+
+        const imgWidget = getImageWidget(this);
+        if (imgWidget) {
+          imgWidget.options = imgWidget.options || {};
+          imgWidget.options.image_upload = true;
+          imgWidget.options.image_folder = "output";
+
+          const self = this;
+          imgWidget.callback = (value) => {
+            onMaskEditorSave(self, value);
+          };
+        }
+        hideWidget(imgWidget);
+
+        /* The hidden image widget is the single source of truth.
+           It holds either "output_image.png [output]" or
+           "clipspace/clipspace-painted-masked-xxx.png [input]". */
+        const raw = imgWidget?.value || "";
+        const stripped = stripAnnotation(raw);
+
+        if (!stripped || stripped === "(None)") {
+          refreshDropdown(this, true);
+          return;
+        }
+
+        /* Reconstruct node.images for MaskEditor */
+        reconstructNodeImages(this);
+
+        /* Load preview from the hidden widget (works for both output and clipspace) */
+        loadPreviewFromWidget(this);
+
+        /* Populate the dropdown with output files only */
+        fetchImageList(this).then((files) => {
+          const combo = this._imageCombo;
+          if (!combo) return;
+
+          combo.options.values = files.length ? files : ["(None)"];
+
+          /* If it's an output image, make sure the combo shows it.
+             If it's a clipspace image, the combo keeps whatever
+             output image was previously selected (restored by LiteGraph). */
+          if (!stripped.startsWith("clipspace/")) {
+            if (files.includes(stripped)) {
+              combo.value = stripped;
+            } else if (files.length) {
+              combo.value = files[0];
+              setSelection(this, files[0]);
+            }
+          }
+
+          this.setDirtyCanvas(true, true);
+        });
+      }, 0);
+
+      return r;
+    };
+  },
+});


### PR DESCRIPTION
This node loads an image from your ``output`` folder and serves as a replacement for ComfyUI's built-in **LoadImageOutput** node since it doesn't work very well, breaks workflows and is regularly broken with comfy updates. A dropdown lists all images sorted by newest first, so the most recent generation is always at the top. When ``Auto refresh after generation`` is enabled, the node automatically picks up newly generated images after each workflow execution — but only when a new file actually appeared, so your current selection stays untouched otherwise.

The node supports the **MaskEditor** (right-click → "Open in MaskEditor"). Painted masks are preserved across workflow executions, tab switches, and page reloads. If no image is available or the selected file was deleted, the node outputs a 512×512 black image to prevent blocking your workflow.

A ``include_subfolders`` property (right-click → Properties) controls whether images from subfolders inside the ``output`` directory are included in the dropdown and refresh functions.