### PR TITLE
fix(load-last-generated): Image preview stuck after comfy update

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.7.1
+- fixed ``Load Last Generated Image`` node preview getting stuck on a previously drawn mask after using the MaskEditor, then refreshing or auto-refreshing to a new image. Caused by ComfyUI frontend >=1.41 introducing a Vue-based node output store that the MaskEditor writes to; stale clipspace data in that store was overriding the node's preview on every frame. The fix clears the store entry and suppresses the Vue overlay when switching back to an output image.
+
 ### v.1.7.0
 - added new ``Load Last Generated Image``-Node as a replacement for ComfyUI's built-in **LoadImageOutput** node. Provides a dropdown of all images in the output folder (newest first), auto-refresh after generation, a manual refresh button, a file upload button, and full MaskEditor support with mask persistence across executions, tab switches, and page reloads. Falls back to a 512×512 black image when no image is available.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: load multiple images via a multi-select dialog with preview; images upload instantly to the input folder and can be output as a list or a batch. Includes boolean AND/OR plus a boolean flip for easy branching, and nodes that bypass or mute other nodes based on a boolean value. Also includes “Fit Image into BBox Mask” to precisely fit/place an image into a mask region’s bounding box—ideal for compositing poses, objects, or partial elements—while preserving aspect ratio and offering alignment options. Adds a bridge from rgthree Power LoRA Loader to the image saver to store LoRA info in metadata, plus settings to show previews of all models & LoRAs across all model loaders - compatible with rgthree's subdirectory view."
-version = "1.7.0"
+version = "1.7.1"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/js/load_last_generated.js
+++ b/web/js/load_last_generated.js
@@ -98,6 +98,22 @@ app.registerExtension({
       }
     };
 
+    /* Clear stale MaskEditor / nodeOutputStore data so that the
+       new Vue-based frontend (>=1.41) does not override our preview.
+       - Deletes app.nodeOutputs[id] → stops onDrawBackground from
+         calling showPreview() with the old clipspace image.
+       - Sets node.hideOutputImages = true → prevents the Vue overlay
+         from rendering the stale Pinia reactive-ref entry.            */
+    const clearNodeOutputStoreEntry = (node) => {
+      try {
+        const nodeId = String(node.id);
+        if (app.nodeOutputs && nodeId in app.nodeOutputs) {
+          delete app.nodeOutputs[nodeId];
+        }
+      } catch { /* older ComfyUI versions – safe to ignore */ }
+      node.hideOutputImages = true;
+    };
+
     /* Select an output-folder image. Sets the hidden widget to
        "rel [output]" and updates node.images + preview. */
     const setSelection = (node, rel) => {
@@ -106,6 +122,7 @@ app.registerExtension({
         if (imgWidget) imgWidget.value = "";
         node.images = null;
         node.imgs = null;
+        clearNodeOutputStoreEntry(node);
         node.setDirtyCanvas(true, true);
         return;
       }
@@ -114,12 +131,14 @@ app.registerExtension({
       const filename = parts.pop();
       const subfolder = parts.join("/");
       node.images = [{ filename, subfolder, type: "output" }];
+      clearNodeOutputStoreEntry(node);
       loadPreview(node, rel, "output");
     };
 
     /* Called when the MaskEditor saves a painted mask to input/clipspace.
        The MaskEditor already updated imgWidget.value to the clipspace path.
-       We just need to update node.images and load the preview. */
+       We just need to update node.images and load the preview.
+       Allow the store / Vue overlay to handle the MaskEditor preview. */
     const onMaskEditorSave = (node, value) => {
       const stripped = stripAnnotation(value);
       if (!stripped.startsWith("clipspace/")) return;
@@ -128,6 +147,7 @@ app.registerExtension({
       const fname = parts.pop();
       const subfolder = parts.join("/");
       node.images = [{ filename: fname, subfolder, type: "input" }];
+      node.hideOutputImages = false;
       loadPreview(node, stripped, "input");
     };
 
@@ -375,6 +395,13 @@ app.registerExtension({
 
         /* Reconstruct node.images for MaskEditor */
         reconstructNodeImages(this);
+
+        /* For output images, clear any stale MaskEditor data from the
+           nodeOutputStore so onDrawBackground doesn't override our preview.
+           For clipspace images, let the store/Vue handle the preview. */
+        if (!stripped.startsWith("clipspace/")) {
+          clearNodeOutputStoreEntry(this);
+        }
 
         /* Load preview from the hidden widget (works for both output and clipspace) */
         loadPreviewFromWidget(this);


### PR DESCRIPTION
- fixed ``Load Last Generated Image`` node preview getting stuck on a previously drawn mask after using the MaskEditor, then refreshing or auto-refreshing to a new image. Caused by ComfyUI frontend >=1.41 introducing a Vue-based node output store that the MaskEditor writes to; stale clipspace data in that store was overriding the node's preview on every frame. The fix clears the store entry and suppresses the Vue overlay when switching back to an output image.