### PR TITLE
fix(multiline-wildcard): after selection will revert back to Select Wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.8.1
 - fixed ``(Impact-Pack) Multiline Wildcard Text`` wildcard dropdown not resetting after selection, which could make users think only one wildcard could be added per session
 
 ### v.1.8.0

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+- fixed ``(Impact-Pack) Multiline Wildcard Text`` wildcard dropdown not resetting after selection, which could make users think only one wildcard could be added per session
+
 ### v.1.8.0
 - added new ``Group Bookmarks``-Node in the ``vsLinx/utility`` group. A UI-only node that adds a collapsible side panel on the right edge of the ComfyUI canvas listing bookmarked workflow groups. Clicking a bookmark entry centers the canvas on that group and zooms to fit it into view. Groups can be organized into named, collapsible sections inside the panel. Section collapsed state and panel visibility are persisted with the workflow.
 - fixed ``Image to Pixel Art`` node name to match naming schema and link to actual documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: load multiple images via a multi-select dialog as a batch or list; load last generated image from the output folder with auto-refresh after generation; fit an image inside a mask’s bounding box for compositing poses, objects, or decals; convert images to pixel art with retro palettes (GameBoy, CGA, NES, Pico-8); upscale to any exact scale factor using an upscale model; boolean AND/OR/flip plus bypass or mute nodes on a boolean for easy workflow branching; multiline wildcard text input with dropdown for Impact-Pack; and append LoRA info from rgthree Power LoRA Loader into image metadata. Also includes settings to show hover previews for all models & LoRAs across all model loaders — compatible with rgthree’s subdirectory view — and a fix (on by default) for “Return type mismatch” errors caused by custom nodes like RES4LYF that extend combo lists such as schedulers."
-version = "1.8.0"
+version = "1.8.1"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/js/impact_multiline_wildcard_text.js
+++ b/web/js/impact_multiline_wildcard_text.js
@@ -1,5 +1,3 @@
-// ComfyUI/web/extensions/impact_multiline_wildcard_text.js
-
 import { app } from "/scripts/app.js";
 import { api } from "/scripts/api.js";
 
@@ -32,7 +30,7 @@ async function loadWildcards() {
     return wildcards_list;
 }
 
-function insertWildcardIntoText(node, wildcard) {
+function insertWildcardIntoText(node, wildcard, dropdown) {
     if (!wildcard) return;
 
     const textWidget =
@@ -54,6 +52,10 @@ function insertWildcardIntoText(node, wildcard) {
         node.widgets_values[0] = newText;
     }
 
+    if (dropdown) {
+        dropdown.value = "Select wildcard";
+    }
+
     app.canvas.setDirty(true);
 }
 
@@ -73,7 +75,7 @@ function setupWildcardDropdown(node) {
         "Select wildcard",
         (value) => {
             if (!value || value === "Select wildcard") return;
-            insertWildcardIntoText(node, value);
+            insertWildcardIntoText(node, value, dropdown);
         },
         {
             values: ["Select wildcard"], 


### PR DESCRIPTION
- fixed ``(Impact-Pack) Multiline Wildcard Text`` wildcard dropdown not resetting after selection, which could make users think only one wildcard could be added per session