### PR TITLE
feat(pipe): Pipe to Any and Any to Pipe nodes added

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Click **"Manage Bookmarks"** on the node to open the bookmark manager. The left 
 
 The side panel can be toggled open and closed via an arrow tab on the right edge of the canvas. Panel visibility, section collapsed state, and the full bookmark list are persisted with the workflow.
 
+#### Any to Pipe
+This node packs up to 5 values of any type into a single pipe connection. All slots are optional — leave any unconnected and only use the ones you need. Slot positions are preserved, so slot_1 in always comes out as slot_1 in the receiving ``Pipe to Any`` node. Useful for reducing visual clutter in large workflows by bundling multiple unrelated values into a single wire that can be routed across the canvas and unpacked later.
+
+#### Pipe to Any
+Unpacks a pipe connection produced by ``Any to Pipe`` back into up to 5 individual outputs. Slots that were left unconnected on the packing end are output as ``None``. Connect only the outputs that were actually packed on the sending end.
+
 #### Power Lora Loader to Prompt (Image Saver)
 This node acts as a bridge between the **Power Lora Loader (rgthree)** node by [rgthree](https://github.com/rgthree/rgthree-comfy) and the **Image Saver** node by [alexopus](https://github.com/alexopus/ComfyUI-Image-Saver).<br>
 You can either **connect a model**, or **provide the id**  or **title** of a `Power Lora Loader (rgthree)` node, along with your prompt as a text string. The node will then **append the LoRAs** in the correct format for the Image Saver node. When you pass this new string to Image Saver as the **positive prompt**, it will save the hashes of the LoRAs for Civitai and other AI platforms while removing the LoRAs from the final string, so your prompt doesn’t look messy.
@@ -141,6 +147,10 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.9.0
+- added new ``Any to Pipe``-Node in the ``vsLinx/utility`` group. Packs up to 5 values of any type into a single pipe connection to reduce visual clutter in large workflows.
+- added new ``Pipe to Any``-Node in the ``vsLinx/utility`` group. Unpacks a pipe connection produced by ``Any to Pipe`` back into up to 5 individual outputs.
+
 ### v.1.8.1
 - fixed ``(Impact-Pack) Multiline Wildcard Text`` wildcard dropdown not resetting after selection, which could make users think only one wildcard could be added per session
 

--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ node_list = [
     "load_last_generated",
     "image_to_pixel_art",
     "group_bookmarks",
+    "pipe_utils",
 ]
 
 NODE_CLASS_MAPPINGS = {}

--- a/nodes/pipe_utils.py
+++ b/nodes/pipe_utils.py
@@ -1,0 +1,64 @@
+class AnyType(str):
+    def __ne__(self, __value: object) -> bool:
+        return False
+
+
+any_t = AnyType("*")
+
+PIPE_TYPE = "VSLINX_PIPE"
+
+
+class vsLinx_AnyToPipe:
+    DESCRIPTION = "Packs up to 5 values of any type into a single pipe connection."
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "optional": {
+                "slot_1": (any_t,),
+                "slot_2": (any_t,),
+                "slot_3": (any_t,),
+                "slot_4": (any_t,),
+                "slot_5": (any_t,),
+            }
+        }
+
+    RETURN_TYPES = (PIPE_TYPE,)
+    RETURN_NAMES = ("pipe",)
+    FUNCTION = "pack"
+    CATEGORY = "vsLinx/utility"
+
+    def pack(self, slot_1=None, slot_2=None, slot_3=None, slot_4=None, slot_5=None):
+        return ((slot_1, slot_2, slot_3, slot_4, slot_5),)
+
+
+class vsLinx_PipeToAny:
+    DESCRIPTION = "Unpacks a pipe into up to 5 individual values."
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "pipe": (PIPE_TYPE,),
+            }
+        }
+
+    RETURN_TYPES = (any_t, any_t, any_t, any_t, any_t)
+    RETURN_NAMES = ("slot_1", "slot_2", "slot_3", "slot_4", "slot_5")
+    FUNCTION = "unpack"
+    CATEGORY = "vsLinx/utility"
+
+    def unpack(self, pipe):
+        slot_1, slot_2, slot_3, slot_4, slot_5 = pipe
+        return (slot_1, slot_2, slot_3, slot_4, slot_5)
+
+
+NODE_CLASS_MAPPINGS = {
+    "vsLinx_AnyToPipe": vsLinx_AnyToPipe,
+    "vsLinx_PipeToAny": vsLinx_PipeToAny,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "vsLinx_AnyToPipe": "Any to Pipe",
+    "vsLinx_PipeToAny": "Pipe to Any",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: load multiple images via a multi-select dialog as a batch or list; load last generated image from the output folder with auto-refresh after generation; fit an image inside a mask’s bounding box for compositing poses, objects, or decals; convert images to pixel art with retro palettes (GameBoy, CGA, NES, Pico-8); upscale to any exact scale factor using an upscale model; boolean AND/OR/flip plus bypass or mute nodes on a boolean for easy workflow branching; multiline wildcard text input with dropdown for Impact-Pack; and append LoRA info from rgthree Power LoRA Loader into image metadata. Also includes settings to show hover previews for all models & LoRAs across all model loaders — compatible with rgthree’s subdirectory view — and a fix (on by default) for “Return type mismatch” errors caused by custom nodes like RES4LYF that extend combo lists such as schedulers."
-version = "1.8.1"
+version = "1.9.0"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/vsLinx_AnyToPipe.md
+++ b/web/docs/vsLinx_AnyToPipe.md
@@ -1,0 +1,26 @@
+This node packs up to 5 values of any type into a single <b>pipe</b> connection. It is the counterpart to <code>Pipe to Any</code> and is intended to reduce visual clutter in large workflows by bundling multiple unrelated values into a single wire that can be routed across the canvas and unpacked later.
+
+This node does the following:
+- Accepts up to 5 inputs of <b>any type</b> (images, masks, numbers, strings, models, etc.). All slots are optional.
+- Packs the 5 values into a single <b>VSLINX_PIPE</b> output that can be passed through the graph as one connection.
+- Unconnected slots are passed as <code>None</code> and are preserved in their positions so the receiving <code>Pipe to Any</code> node outputs them at the correct slot index.
+
+Parameters:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| slot_1 | ANY | First value to pack into the pipe. Optional. |
+| slot_2 | ANY | Second value to pack into the pipe. Optional. |
+| slot_3 | ANY | Third value to pack into the pipe. Optional. |
+| slot_4 | ANY | Fourth value to pack into the pipe. Optional. |
+| slot_5 | ANY | Fifth value to pack into the pipe. Optional. |
+
+Outputs:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| pipe | VSLINX_PIPE | A single pipe connection carrying all 5 slot values. Connect this to a <code>Pipe to Any</code> node to retrieve them. |
+
+Notes:
+- All 5 input slots are optional — you can leave any number of them unconnected and only use the slots you need.
+- Slot positions are preserved: slot_1 in always comes out as slot_1 in the receiving <code>Pipe to Any</code> node, regardless of which slots are populated.
+- The pipe type is <code>VSLINX_PIPE</code> and is only compatible with the <code>Pipe to Any</code> node from this pack.
+- The node does not modify, copy, or serialize any of the values — references are passed as-is, so tensors are not duplicated in memory.

--- a/web/docs/vsLinx_PipeToAny.md
+++ b/web/docs/vsLinx_PipeToAny.md
@@ -1,0 +1,26 @@
+This node unpacks a <b>pipe</b> connection back into up to 5 individual outputs of any type. It is the counterpart to <code>Any to Pipe</code> and is intended to be placed at the destination end of a pipe wire to retrieve the original values.
+
+This node does the following:
+- Accepts a single <b>VSLINX_PIPE</b> input produced by an <code>Any to Pipe</code> node.
+- Unpacks the pipe and exposes each of the 5 slot values as individual outputs.
+- Slots that were left unconnected on the packing end are output as <code>None</code>.
+
+Parameters:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| pipe | VSLINX_PIPE | A pipe connection produced by an <code>Any to Pipe</code> node. |
+
+Outputs:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| slot_1 | ANY | The value that was connected to slot_1 on the <code>Any to Pipe</code> node. |
+| slot_2 | ANY | The value that was connected to slot_2 on the <code>Any to Pipe</code> node. |
+| slot_3 | ANY | The value that was connected to slot_3 on the <code>Any to Pipe</code> node. |
+| slot_4 | ANY | The value that was connected to slot_4 on the <code>Any to Pipe</code> node. |
+| slot_5 | ANY | The value that was connected to slot_5 on the <code>Any to Pipe</code> node. |
+
+Notes:
+- Only connect outputs that were actually packed on the sending end. Connecting a <code>None</code> slot to a node that requires a real value will cause a runtime error in that downstream node.
+- Slot order is preserved: slot_1 always corresponds to slot_1 from the <code>Any to Pipe</code> node.
+- The pipe type is <code>VSLINX_PIPE</code> and is only compatible with the <code>Any to Pipe</code> node from this pack.
+- Values are passed by reference — no copying or deserialization occurs, so tensors are not duplicated in memory.


### PR DESCRIPTION
- added new ``Any to Pipe``-Node in the ``vsLinx/utility`` group. Packs up to 5 values of any type into a single pipe connection to reduce visual clutter in large workflows.
- added new ``Pipe to Any``-Node in the ``vsLinx/utility`` group. Unpacks a pipe connection produced by ``Any to Pipe`` back into up to 5 individual outputs.