### PR TITLE
feat(anima-tiled-sampler): all-in-one Anima LLLite tiled ControlNet sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ Decoding fewer latents per call **lowers peak VRAM** and on many setups **speeds
 #### VAE Decode Tiled (Batched)
 The same idea applied to ComfyUI's **VAE Decode (Tiled)** node: all original fields (``tile_size``, ``overlap``, ``temporal_size``, ``temporal_overlap``) are kept unchanged and a ``batch_size`` field is added on top. ``batch_size`` controls *how many latents* are decoded per call, while the tiling fields control how each individual latent is split spatially — the two are independent and combine freely.
 
+### Sampling
+#### Anima LLLite Tiled ControlNet Sampler
+An all-in-one node that replaces a whole manual <b>Anima ControlNet-LLLite tiled upscale</b> graph (image tiling → per-tile VAE encode / LLLite apply / KSampler / VAE decode → batch + untile) with a single node. The grid is <b>dynamic</b>: change ``rows``/``columns`` and the node loops the correct number of times instead of forcing you to wire up one sampler chain per tile.
+
+For every tile in the ``rows`` × ``columns`` grid it applies **Anima ControlNet-LLLite** to the model using that tile as the control image, **VAE-encodes** the tile, runs the **KSampler** with the shared ``positive``/``negative`` conditioning, and **VAE-decodes** the result. When all tiles are done they are feathered along their overlaps and **stitched back** into a single image (same tiling/feathering math as comfyui_essentials Image Tile / Image Untile). All tiles share the same ``seed``.
+
+It exposes the sampler fields (``seed``, ``steps``, ``cfg``, ``sampler``, ``scheduler``, ``denoise``), the LLLite fields (``LLLite Model``, ``strength``, ``start_percent``, ``end_percent``, ``preserve_wrapper``) and the tiling fields (``rows``, ``columns``, ``overlap``, ``overlap_x``, ``overlap_y``, ``method``). The overlaps used for stitching are the ones actually computed during tiling, so the geometry always lines up. For lower VRAM, use more ``rows``/``columns`` (smaller tiles).
+
+**No extra node packs are required** - the Anima ControlNet-LLLite apply logic is bundled (vendored from [kohya-ss/ComfyUI-Anima-LLLite](https://github.com/kohya-ss/ComfyUI-Anima-LLLite), see [Credits](#credits)), so the node works on its own. It can also be found in the node search under terms like ``Anima LLLite Tiled Sampler`` or ``Anima Tile Upscale``.
+
 ### Inpaint helper
 #### Fit Image into BBox Mask
 This node fits an image <b>inside the bounding box region of a mask</b> and places it into a destination image (or a blank canvas). It’s useful for workflows where you want to insert or align a smaller image (e.g. pose, object, logo, patch) into a specific masked region while keeping correct proportions.
@@ -185,6 +195,9 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.11.0
+- added new ``Anima LLLite Tiled ControlNet Sampler``-Node in the ``vsLinx/sampling`` group. An all-in-one node that tiles an image into a dynamic ``rows`` × ``columns`` grid and, for each tile, applies Anima ControlNet-LLLite (tile as control), VAE-encodes, KSamples and VAE-decodes, then feathers and stitches the tiles back together — replacing a whole manual tile/sample/untile graph with a single node. Exposes the sampler, LLLite and tiling (``overlap``/``overlap_x``/``overlap_y``/``method``) fields. Needs no extra node packs — the Anima ControlNet-LLLite logic is bundled (vendored from kohya-ss, see Credits).
+
 ### v.1.10.0
 - added new ``Forward/Bypass-Mute on State (Any)``-Node in the ``vsLinx/utility`` group. Forwards any value while mirroring the bypass/mute state of the node connected to its ``trigger`` input onto the directly connected downstream node(s) (bypass → bypass, mute → mute, normal → normal). Includes an ``Ignore subgraph boundary`` toggle to follow the trigger across subgraph boundaries until a real node, and a ``Mirror this node's own bypass/mute`` toggle to also propagate this node's own state downstream.
 - added new ``VAE Decode (Batched)`` and ``VAE Decode Tiled (Batched)`` nodes in the ``vsLinx/latent`` group. They work exactly like ComfyUI's built-in VAE Decode / VAE Decode (Tiled) but add a ``batch_size`` field that controls how many latents are decoded by the VAE at once (default ``1``). Decoding fewer at a time lowers peak VRAM and can speed up generation; values >= the batch size behave identically to the built-in nodes.
@@ -269,3 +282,7 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 
 ### v1.0.0 
 * initial release
+
+## Credits
+- **[kohya-ss](https://github.com/kohya-ss)** for **[ComfyUI-Anima-LLLite](https://github.com/kohya-ss/ComfyUI-Anima-LLLite)** (Apache License 2.0). The ``Anima LLLite Tiled ControlNet Sampler`` node bundles a vendored copy of its ControlNet-LLLite apply logic (under ``nodes/_vendor``, with the Apache license kept alongside) so the node runs without requiring that pack to be installed.
+- **[ltdrdata](https://github.com/ltdrdata)** for **[ComfyUI-Impact-Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack)**, which powers the ``(Impact-Pack) Interactive Detailer`` and ``(Impact-Pack) Multiline Wildcard Text`` nodes.

--- a/__init__.py
+++ b/__init__.py
@@ -22,6 +22,7 @@ node_list = [
     "group_bookmarks",
     "pipe_utils",
     "vae_decode_batched",
+    "anima_lllite_tiled_sampler",
 ]
 
 NODE_CLASS_MAPPINGS = {}

--- a/nodes/_vendor/LICENSE-Anima-LLLite
+++ b/nodes/_vendor/LICENSE-Anima-LLLite
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/nodes/_vendor/__init__.py
+++ b/nodes/_vendor/__init__.py
@@ -1,0 +1,3 @@
+# Vendored third-party code. See LICENSE-Anima-LLLite and the README "Credits"
+# section for attribution. Kept in a private subpackage so it does not register
+# any nodes of its own.

--- a/nodes/_vendor/anima_lllite_apply.py
+++ b/nodes/_vendor/anima_lllite_apply.py
@@ -1,0 +1,227 @@
+# ---------------------------------------------------------------------------
+# Adapted from kohya-ss/ComfyUI-Anima-LLLite (Apache License 2.0) — the
+# `AnimaLLLiteApply` node's apply logic, refactored from a ComfyUI node class
+# into a plain `apply_anima_lllite()` function so the vsLinx "Anima LLLite
+# Tiled ControlNet Sampler" node can patch a model without requiring that pack
+# to be installed.
+# Source: https://github.com/kohya-ss/ComfyUI-Anima-LLLite
+# The Apache 2.0 license text is kept alongside this file as
+# `LICENSE-Anima-LLLite`. See the README "Credits" section.
+# ---------------------------------------------------------------------------
+"""Self-contained Anima ControlNet-LLLite model patcher.
+
+``apply_anima_lllite`` mirrors ``AnimaLLLiteApply.apply``: it loads an LLLite
+weights file, builds the matching ``ControlNetLLLiteDiT`` from the trained
+metadata, and installs a model_function_wrapper (scoped to a model clone) that
+feeds the given control image into the LLLite modules over a sampling-progress
+window. Returns the patched MODEL.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from .control_net_lllite_anima import (
+    ASPP_DEFAULT_DILATIONS,
+    ControlNetLLLiteDiT,
+    load_lllite_weights,
+    read_lllite_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _get_inner_dit(model) -> torch.nn.Module:
+    """Reach the underlying Anima DiT (nn.Module) from a ComfyUI ModelPatcher."""
+    inner = getattr(model, "model", None)
+    if inner is None:
+        raise RuntimeError("Input MODEL has no .model attribute (not a ModelPatcher?)")
+    dit = getattr(inner, "diffusion_model", None)
+    if dit is None:
+        raise RuntimeError("MODEL.model has no .diffusion_model — not a UNet/DiT model?")
+    return dit
+
+
+def _target_cond_hw(latent_h: int, latent_w: int, patch_spatial: int = 2) -> tuple[int, int]:
+    """Return the (H, W) the cond image / mask must be resized to.
+
+    The LLLite ``conditioning1`` Conv has stride 16, so the cond image must be
+    sized to ``latent_HW * 8`` in input pixel space (= ``token_HW * 16`` after
+    DiT patchify with patch_spatial=2). The DiT internally pads the latent up to
+    a multiple of ``patch_spatial``, so we mirror that rounding here.
+    """
+    padded_h = ((latent_h + patch_spatial - 1) // patch_spatial) * patch_spatial
+    padded_w = ((latent_w + patch_spatial - 1) // patch_spatial) * patch_spatial
+    return padded_h * 8, padded_w * 8
+
+
+def _prepare_cond_image(image: torch.Tensor, latent_h: int, latent_w: int,
+                        device: torch.device, dtype: torch.dtype,
+                        patch_spatial: int = 2) -> torch.Tensor:
+    """ComfyUI IMAGE (B,H,W,3) in [0,1] → (1,3,H*8,W*8) in [-1,1]."""
+    if image.ndim == 4 and image.shape[-1] == 3:
+        img = image.permute(0, 3, 1, 2).contiguous()
+    else:
+        raise ValueError(f"Unexpected cond image shape: {tuple(image.shape)} (expected B,H,W,3)")
+
+    img = img[:1]  # use first frame only
+    target_h, target_w = _target_cond_hw(latent_h, latent_w, patch_spatial)
+    if img.shape[-2] != target_h or img.shape[-1] != target_w:
+        img = F.interpolate(img, size=(target_h, target_w), mode="bicubic", align_corners=False)
+        img = img.clamp(0.0, 1.0)
+    img = img * 2.0 - 1.0
+    return img.to(device=device, dtype=dtype)
+
+
+def _prepare_mask(mask: torch.Tensor, latent_h: int, latent_w: int,
+                  device: torch.device, dtype: torch.dtype,
+                  patch_spatial: int = 2) -> torch.Tensor:
+    """ComfyUI MASK (B,H,W) in [0,1] → (1,1,H*8,W*8) binarized at 0.5."""
+    if mask.ndim == 3:
+        m = mask.unsqueeze(1)
+    elif mask.ndim == 4 and mask.shape[1] == 1:
+        m = mask
+    else:
+        raise ValueError(f"Unexpected mask shape: {tuple(mask.shape)} (expected B,H,W or B,1,H,W)")
+
+    m = m[:1]
+    target_h, target_w = _target_cond_hw(latent_h, latent_w, patch_spatial)
+    if m.shape[-2] != target_h or m.shape[-1] != target_w:
+        m = F.interpolate(m.float(), size=(target_h, target_w), mode="nearest")
+    m = (m >= 0.5).to(dtype=dtype)
+    return m.to(device=device)
+
+
+def _build_inpaint_cond_image(rgb_pm1: torch.Tensor, mask01: torch.Tensor,
+                              masked_input: bool) -> torch.Tensor:
+    """rgb_pm1: (1,3,H,W) in [-1,1], mask01: (1,1,H,W) in {0,1}. Returns (1,4,H,W)."""
+    if masked_input:
+        keep = (mask01 < 0.5).to(rgb_pm1.dtype)
+        rgb_pm1 = rgb_pm1 * keep
+    mask_pm1 = mask01.to(rgb_pm1.dtype) * 2.0 - 1.0
+    return torch.cat([rgb_pm1, mask_pm1], dim=1)
+
+
+def apply_anima_lllite(model, weights_path: str, image: torch.Tensor, strength: float,
+                       start_percent: float, end_percent: float,
+                       preserve_wrapper: bool = True, mask: Optional[torch.Tensor] = None):
+    """Patch ``model`` with Anima ControlNet-LLLite and return the patched clone.
+
+    ``weights_path`` is the resolved path to the LLLite ``.safetensors`` file.
+    """
+    if weights_path is None or not os.path.isfile(weights_path):
+        raise FileNotFoundError(f"LLLite weights not found: {weights_path}")
+
+    # Architecture is fully determined by the trained weights — read everything
+    # from metadata rather than exposing knobs that would just cause load errors.
+    meta = read_lllite_metadata(weights_path)
+    ce_dim = int(meta.get("lllite.cond_emb_dim", 32))
+    m_dim = int(meta.get("lllite.mlp_dim", 64))
+    tl = meta.get("lllite.target_atomics", meta.get("lllite.target_layers", "self_attn_q"))
+    cond_dim = int(meta.get("lllite.cond_dim", 64))
+    cond_resblocks = int(meta.get("lllite.cond_resblocks", 1))
+    use_aspp = str(meta.get("lllite.use_aspp", "false")).lower() == "true"
+    aspp_dilations_meta = meta.get("lllite.aspp_dilations")
+    if use_aspp and aspp_dilations_meta:
+        aspp_dilations = tuple(int(d) for d in aspp_dilations_meta.split(",") if d.strip())
+    else:
+        aspp_dilations = ASPP_DEFAULT_DILATIONS
+    cond_in_channels = int(meta.get("lllite.cond_in_channels", 3))
+    inpaint_masked_input = str(meta.get("lllite.inpaint_masked_input", "false")).lower() == "true"
+
+    # Mask / cond_in_channels consistency: 4ch weights need a MASK, 3ch ignore it.
+    if cond_in_channels == 4 and mask is None:
+        raise ValueError(
+            f"LLLite weights '{os.path.basename(weights_path)}' were trained with "
+            f"cond_in_channels=4 (inpaint mode) and require a MASK input."
+        )
+    if cond_in_channels != 4 and mask is not None:
+        logger.warning(
+            "LLLite weights '%s' are %dch; the provided MASK input will be ignored.",
+            os.path.basename(weights_path), cond_in_channels,
+        )
+        mask = None
+
+    dit = _get_inner_dit(model)
+    patch_spatial = int(getattr(dit, "patch_spatial", 2))
+    lllite = ControlNetLLLiteDiT(
+        dit,
+        cond_emb_dim=ce_dim,
+        mlp_dim=m_dim,
+        target_layers=tl,
+        multiplier=strength,
+        cond_dim=cond_dim,
+        cond_resblocks=cond_resblocks,
+        use_aspp=use_aspp,
+        aspp_dilations=aspp_dilations,
+        cond_in_channels=cond_in_channels,
+        inpaint_masked_input=inpaint_masked_input,
+    )
+    load_lllite_weights(lllite, weights_path, strict=False)
+    lllite.eval().requires_grad_(False)
+
+    # Convert percent range -> sigma range (start_percent=0 → sigma_max).
+    model_sampling = model.get_model_object("model_sampling")
+    sigma_start = float(model_sampling.percent_to_sigma(start_percent))
+    sigma_end = float(model_sampling.percent_to_sigma(end_percent))
+
+    src_image = image.detach().clone()
+    src_mask = mask.detach().clone() if mask is not None else None
+    is_inpaint = cond_in_channels == 4
+
+    cache = {"cond_image_pp": None, "key": None, "lllite_loaded_to": None}
+
+    # Capture any previously-installed wrapper BEFORE cloning so a second
+    # wrapper-installing node doesn't silently no-op the first.
+    old_wrapper = model.model_options.get("model_function_wrapper")
+
+    def _call_next(apply_model, input_x, timestep, c):
+        if preserve_wrapper and old_wrapper is not None:
+            return old_wrapper(apply_model, {"input": input_x, "timestep": timestep, "c": c})
+        return apply_model(input_x, timestep, **c)
+
+    def wrapper(apply_model, args):
+        input_x = args["input"]
+        timestep = args["timestep"]
+        c = args["c"]
+
+        sigma = float(timestep.max().item())
+        if not (sigma_end <= sigma <= sigma_start):
+            return _call_next(apply_model, input_x, timestep, c)
+
+        latent_h, latent_w = int(input_x.shape[-2]), int(input_x.shape[-1])
+        device = input_x.device
+        dtype = input_x.dtype
+
+        tag = (device, dtype)
+        if cache["lllite_loaded_to"] != tag:
+            lllite.to(device=device, dtype=dtype)
+            cache["lllite_loaded_to"] = tag
+            cache["cond_image_pp"] = None
+
+        key = (latent_h, latent_w, device, dtype)
+        if cache["key"] != key or cache["cond_image_pp"] is None:
+            rgb = _prepare_cond_image(src_image, latent_h, latent_w, device, dtype, patch_spatial)
+            if is_inpaint:
+                mk = _prepare_mask(src_mask, latent_h, latent_w, device, dtype, patch_spatial)
+                cache["cond_image_pp"] = _build_inpaint_cond_image(rgb, mk, inpaint_masked_input)
+            else:
+                cache["cond_image_pp"] = rgb
+            cache["key"] = key
+
+        lllite.set_multiplier(strength)
+        lllite.set_cond_image(cache["cond_image_pp"])
+        lllite.apply_to()
+        try:
+            return _call_next(apply_model, input_x, timestep, c)
+        finally:
+            lllite.restore()
+            lllite.clear_cond_image()
+
+    m = model.clone()
+    m.set_model_unet_function_wrapper(wrapper)
+    return m

--- a/nodes/_vendor/control_net_lllite_anima.py
+++ b/nodes/_vendor/control_net_lllite_anima.py
@@ -1,0 +1,551 @@
+# ---------------------------------------------------------------------------
+# VENDORED from kohya-ss/ComfyUI-Anima-LLLite (Apache License 2.0).
+# Source: https://github.com/kohya-ss/ComfyUI-Anima-LLLite
+# Copied verbatim except for this banner so the vsLinx "Anima LLLite Tiled
+# ControlNet Sampler" node can run without requiring that pack to be installed.
+# The Apache 2.0 license text is kept alongside this file as
+# `LICENSE-Anima-LLLite`. See the README "Credits" section.
+# ---------------------------------------------------------------------------
+"""ControlNet-LLLite for Anima (DiT) — ComfyUI port (v2 architecture).
+
+Adapted from kohya-ss/sd-scripts. The on-disk weight format is the v2
+named-key format (per-module key prefix = lllite_name, shared encoder under
+``lllite_conditioning1.*``, depth embedding split per-module as
+``{name}.depth_embed``); legacy ``lllite_modules.*`` files are rejected.
+
+Differences vs. the sd-scripts reference (``networks/control_net_lllite_anima.py``):
+  * No dependency on ``library.utils`` — uses stdlib logging.
+  * Module discovery filters the LLM-Adapter sub-tree by class identity in
+    addition to the path-based check (ComfyUI ships two distinct ``Attention``
+    classes that share the bare class name).
+  * ``LLLiteModuleDiT`` keeps a ``restore()`` method (and an idempotent
+    ``apply_to()``); ComfyUI patches/unpatches the original Linear around
+    every sampler call via ``set_model_unet_function_wrapper``.
+  * Forward pass casts ``x`` and ``cond_emb`` to the LLLite parameter dtype
+    so autocast / mixed-precision flows that hand us a different dtype than
+    the LLLite weights still work.
+  * CFG batch-size and sequence-length mismatches fall back to identity
+    instead of asserting, so a slightly-off cond image cannot abort sampling.
+  * The training-side ``AnimaControlNetLLLiteWrapper`` is omitted; ComfyUI
+    integrates via ``model_function_wrapper`` in nodes.py instead.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+logger = logging.getLogger(__name__)
+
+
+# Class names of the modules that LLLite injects into. The LLM-Adapter uses
+# a different ``Attention`` class with the same bare name; we filter it by
+# path (``llm_adapter`` in the qualified name) and by the ``is_selfattn``
+# attribute presence.
+TARGET_ATTENTION_CLASS = "Attention"
+TARGET_MLP_CLASS = "GPT2FeedForward"
+LLM_ADAPTER_NAME = "llm_adapter"
+
+LLLITE_ARCH_VERSION = "2"
+
+
+# ----------------------------------------------------------------------------
+# target_layers: atomic specifiers and presets
+# ----------------------------------------------------------------------------
+
+ATOMIC_SPECIFIERS: Tuple[str, ...] = (
+    "self_attn_q_pre",
+    "self_attn_kv_pre",
+    "cross_attn_q_pre",
+    "mlp_fc1_pre",
+)
+
+PRESETS: dict = {
+    "self_attn_q":            ("self_attn_q_pre",),
+    "self_attn_qkv":          ("self_attn_q_pre", "self_attn_kv_pre"),
+    "self_attn_qkv_cross_q":  ("self_attn_q_pre", "self_attn_kv_pre", "cross_attn_q_pre"),
+}
+
+
+def parse_target_layers(spec: str) -> Tuple[str, ...]:
+    """Resolve a ``target_layers`` spec to a canonical atomic tuple.
+
+    Accepts a preset name (``"self_attn_qkv"``) or a comma-separated list of
+    atomic specifiers (``"self_attn_q_pre,mlp_fc1_pre"``). Returns the atomics
+    in ``ATOMIC_SPECIFIERS`` order with duplicates removed.
+    """
+    if not isinstance(spec, str):
+        raise TypeError(f"target_layers must be str, got {type(spec).__name__}")
+    spec = spec.strip()
+    if not spec:
+        raise ValueError("target_layers spec is empty")
+
+    if spec in PRESETS:
+        parts = list(PRESETS[spec])
+    else:
+        parts = [p.strip() for p in spec.split(",") if p.strip()]
+        bad = [p for p in parts if p not in ATOMIC_SPECIFIERS]
+        if bad:
+            raise ValueError(
+                f"unknown target_layers atomic specifier(s): {bad}. "
+                f"valid atomic={list(ATOMIC_SPECIFIERS)}, presets={list(PRESETS)}"
+            )
+
+    return tuple(a for a in ATOMIC_SPECIFIERS if a in parts)
+
+
+# ----------------------------------------------------------------------------
+# Conditioning1 trunk (v2)
+# ----------------------------------------------------------------------------
+
+def _gn(channels: int) -> nn.GroupNorm:
+    g = 8
+    while g > 1 and channels % g != 0:
+        g //= 2
+    return nn.GroupNorm(g, channels)
+
+
+class _ResBlock(nn.Module):
+    def __init__(self, ch: int):
+        super().__init__()
+        self.norm1 = _gn(ch)
+        self.conv1 = nn.Conv2d(ch, ch, kernel_size=3, padding=1)
+        self.norm2 = _gn(ch)
+        self.conv2 = nn.Conv2d(ch, ch, kernel_size=3, padding=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.conv1(F.silu(self.norm1(x)))
+        h = self.conv2(F.silu(self.norm2(h)))
+        return x + h
+
+
+ASPP_DEFAULT_DILATIONS: Tuple[int, ...] = (1, 2, 4, 8)
+
+
+class _ASPP(nn.Module):
+    def __init__(self, ch: int, dilations: Tuple[int, ...] = ASPP_DEFAULT_DILATIONS):
+        super().__init__()
+        assert len(dilations) >= 1, "ASPP needs at least one dilation"
+        branches = []
+        for d in dilations:
+            if d == 1:
+                conv = nn.Conv2d(ch, ch, kernel_size=1)
+            else:
+                conv = nn.Conv2d(ch, ch, kernel_size=3, padding=d, dilation=d)
+            branches.append(nn.Sequential(conv, _gn(ch), nn.SiLU()))
+        self.branches = nn.ModuleList(branches)
+
+        self.global_pool = nn.AdaptiveAvgPool2d(1)
+        self.global_conv = nn.Sequential(nn.Conv2d(ch, ch, kernel_size=1), _gn(ch), nn.SiLU())
+
+        n_branches = len(dilations) + 1
+        self.proj = nn.Sequential(
+            nn.Conv2d(ch * n_branches, ch, kernel_size=1), _gn(ch), nn.SiLU()
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h, w = x.shape[-2:]
+        outs = [b(x) for b in self.branches]
+        g = self.global_conv(self.global_pool(x))
+        g = F.interpolate(g, size=(h, w), mode="bilinear", align_corners=False)
+        outs.append(g)
+        return self.proj(torch.cat(outs, dim=1))
+
+
+class _Conditioning1(nn.Module):
+    def __init__(
+        self,
+        cond_dim: int,
+        cond_emb_dim: int,
+        n_resblocks: int,
+        use_aspp: bool = False,
+        aspp_dilations: Tuple[int, ...] = ASPP_DEFAULT_DILATIONS,
+        cond_in_channels: int = 3,
+    ):
+        super().__init__()
+        assert cond_dim % 2 == 0, f"cond_dim must be even, got {cond_dim}"
+        assert cond_in_channels >= 1, f"cond_in_channels must be >= 1, got {cond_in_channels}"
+        ch_half = cond_dim // 2
+
+        self.cond_in_channels = cond_in_channels
+        self.conv1 = nn.Conv2d(cond_in_channels, ch_half, kernel_size=4, stride=4, padding=0)
+        self.norm1 = _gn(ch_half)
+        self.conv2 = nn.Conv2d(ch_half, ch_half, kernel_size=3, stride=1, padding=1)
+        self.norm2 = _gn(ch_half)
+        self.conv3 = nn.Conv2d(ch_half, cond_dim, kernel_size=4, stride=4, padding=0)
+        self.norm3 = _gn(cond_dim)
+
+        self.resblocks = nn.ModuleList([_ResBlock(cond_dim) for _ in range(n_resblocks)])
+        self.aspp = _ASPP(cond_dim, aspp_dilations) if use_aspp else None
+
+        self.proj = nn.Conv2d(cond_dim, cond_emb_dim, kernel_size=1)
+        self.out_norm = nn.LayerNorm(cond_emb_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = F.silu(self.norm1(self.conv1(x)))
+        h = F.silu(self.norm2(self.conv2(h)))
+        h = F.silu(self.norm3(self.conv3(h)))
+        for rb in self.resblocks:
+            h = rb(h)
+        if self.aspp is not None:
+            h = self.aspp(h)
+        h = self.proj(h)
+        b, c, hh, ww = h.shape
+        h = h.view(b, c, hh * ww).permute(0, 2, 1).contiguous()
+        h = self.out_norm(h)
+        return h
+
+
+# ----------------------------------------------------------------------------
+# LLLite module (v2: FiLM + SiLU + 5D path + depth embedding)
+# ----------------------------------------------------------------------------
+
+class LLLiteModuleDiT(nn.Module):
+    def __init__(
+        self,
+        name: str,
+        org_module: nn.Linear,
+        cond_emb_dim: int,
+        mlp_dim: int,
+        dropout: Optional[float] = None,
+        multiplier: float = 1.0,
+    ):
+        super().__init__()
+        self.lllite_name = name
+        # Wrap in a list so the original Linear is not registered as a submodule
+        # and its weights stay out of state_dict.
+        self.org_module = [org_module]
+        self.cond_emb_dim = cond_emb_dim
+        self.mlp_dim = mlp_dim
+        self.dropout = dropout
+        self.multiplier = multiplier
+
+        in_dim = org_module.in_features
+
+        self.down = nn.Linear(in_dim, mlp_dim)
+        self.mid = nn.Linear(mlp_dim + cond_emb_dim, mlp_dim)
+
+        # FiLM: cond_local -> (gamma, beta), zero-init for identity at start.
+        self.cond_to_film = nn.Linear(cond_emb_dim, 2 * mlp_dim)
+        nn.init.zeros_(self.cond_to_film.weight)
+        nn.init.zeros_(self.cond_to_film.bias)
+
+        self.up = nn.Linear(mlp_dim, in_dim)
+        nn.init.zeros_(self.up.weight)
+        nn.init.zeros_(self.up.bias)
+
+        self.cond_emb: Optional[torch.Tensor] = None
+        self.org_forward = None
+
+        # Set by the parent ControlNetLLLiteDiT after construction.
+        self.layer_idx: int = -1
+        self._depth_embeds_ref: List[nn.Parameter] = []
+
+    def apply_to(self):
+        if self.org_forward is None:
+            self.org_forward = self.org_module[0].forward
+            self.org_module[0].forward = self.forward
+
+    def restore(self):
+        if self.org_forward is not None:
+            self.org_module[0].forward = self.org_forward
+            self.org_forward = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Input layouts:
+        #   self/cross attention q/k/v: (B, S, D) — already flattened in the Anima block
+        #   mlp.layer1:                 (B, T, H, W, D) — passed un-flattened
+        # Flatten the 5D case to 3D for the LLLite path and reshape on exit.
+        if self.multiplier == 0.0 or self.cond_emb is None:
+            return self.org_forward(x)
+
+        orig_shape = x.shape
+        is_5d = x.dim() == 5
+        if is_5d:
+            B, T, H, W, D = orig_shape
+            x = x.reshape(B, T * H * W, D)
+
+        cx = self.cond_emb  # (B_c, S, cond_emb_dim)
+
+        # Broadcast cond_emb to the runtime batch (CFG cond+uncond, multi-cond).
+        if x.shape[0] != cx.shape[0]:
+            if x.shape[0] % cx.shape[0] != 0:
+                return self.org_forward(x.reshape(orig_shape) if is_5d else x)
+            cx = cx.repeat(x.shape[0] // cx.shape[0], 1, 1)
+
+        if x.shape[1] != cx.shape[1]:
+            return self.org_forward(x.reshape(orig_shape) if is_5d else x)
+
+        # Run the LLLite mini-MLP in its own parameter dtype, then cast the
+        # correction back to ``x``'s dtype before adding. Robust to autocast
+        # flows where x and LLLite weights have different dtypes.
+        param_dtype = self.down.weight.dtype
+        x_proc = x if x.dtype == param_dtype else x.to(param_dtype)
+        if cx.dtype != param_dtype or cx.device != x.device:
+            cx = cx.to(device=x.device, dtype=param_dtype)
+
+        # Per-module depth embedding (zero-init so it's a no-op at train start).
+        if self._depth_embeds_ref:
+            depth_e = self._depth_embeds_ref[0][self.layer_idx]
+            if depth_e.dtype != param_dtype or depth_e.device != x.device:
+                depth_e = depth_e.to(device=x.device, dtype=param_dtype)
+            cond_local = cx + depth_e
+        else:
+            cond_local = cx
+
+        h = F.silu(self.down(x_proc))
+
+        gb = self.cond_to_film(cond_local)
+        gamma, beta = gb.chunk(2, dim=-1)
+
+        m = self.mid(torch.cat([cond_local, h], dim=-1))
+        m = m * (1 + gamma) + beta
+        m = F.silu(m)
+
+        if self.dropout is not None and self.training:
+            m = F.dropout(m, p=self.dropout)
+
+        out = self.up(m) * self.multiplier
+        if out.dtype != x.dtype:
+            out = out.to(x.dtype)
+
+        y = self.org_forward(x + out)
+
+        if is_5d:
+            # org Linear out_features may differ from in_features — recover with -1.
+            y = y.reshape(orig_shape[0], orig_shape[1], orig_shape[2], orig_shape[3], -1)
+        return y
+
+
+# ----------------------------------------------------------------------------
+# ControlNetLLLiteDiT
+# ----------------------------------------------------------------------------
+
+class ControlNetLLLiteDiT(nn.Module):
+    def __init__(
+        self,
+        dit: nn.Module,
+        cond_emb_dim: int = 32,
+        mlp_dim: int = 64,
+        target_layers: str = "self_attn_q",
+        dropout: Optional[float] = None,
+        multiplier: float = 1.0,
+        cond_dim: int = 64,
+        cond_resblocks: int = 1,
+        use_aspp: bool = False,
+        aspp_dilations: Tuple[int, ...] = ASPP_DEFAULT_DILATIONS,
+        cond_in_channels: int = 3,
+        inpaint_masked_input: bool = False,
+    ):
+        super().__init__()
+
+        atomics = parse_target_layers(target_layers)
+
+        self.cond_emb_dim = cond_emb_dim
+        self.mlp_dim = mlp_dim
+        self.target_layers = target_layers
+        self.target_atomics = atomics
+        self.dropout = dropout
+        self.multiplier = multiplier
+        self.cond_dim = cond_dim
+        self.cond_resblocks = cond_resblocks
+        self.use_aspp = use_aspp
+        self.aspp_dilations = tuple(aspp_dilations) if use_aspp else ()
+        # 4ch (RGB+mask) inpainting metadata. `inpaint_masked_input` records the training-time
+        # RGB-masking policy for cond_image preparation; it does not alter the forward pass here.
+        self.cond_in_channels = cond_in_channels
+        self.inpaint_masked_input = inpaint_masked_input
+
+        self.conditioning1 = _Conditioning1(
+            cond_dim, cond_emb_dim, cond_resblocks,
+            use_aspp=use_aspp, aspp_dilations=aspp_dilations,
+            cond_in_channels=cond_in_channels,
+        )
+
+        modules = self._create_modules(dit, cond_emb_dim, mlp_dim, atomics, dropout, multiplier)
+        self.lllite_modules = nn.ModuleList(modules)
+
+        n = len(self.lllite_modules)
+        self.depth_embeds = nn.Parameter(torch.zeros(n, cond_emb_dim))
+        for i, m in enumerate(self.lllite_modules):
+            m.layer_idx = i
+            m._depth_embeds_ref = [self.depth_embeds]
+
+        aspp_info = f"aspp={'on' + str(list(self.aspp_dilations)) if use_aspp else 'off'}"
+        inpaint_info = (
+            f", inpaint=on(masked_input={inpaint_masked_input})" if cond_in_channels != 3 else ""
+        )
+        logger.info(
+            "ControlNet-LLLite (Anima v%s): created %d modules for target=%r "
+            "(atomics=%s), cond_in_channels=%d, cond_dim=%d, cond_resblocks=%d, %s, "
+            "cond_emb_dim=%d, mlp_dim=%d%s",
+            LLLITE_ARCH_VERSION, n, target_layers, list(atomics),
+            cond_in_channels, cond_dim, cond_resblocks, aspp_info, cond_emb_dim, mlp_dim,
+            inpaint_info,
+        )
+
+    @staticmethod
+    def _attn_atomic_match(is_self_attn: bool, child_name: str, atomics: Tuple[str, ...]) -> bool:
+        if "output_proj" in child_name:
+            return False
+        if is_self_attn:
+            if child_name == "q_proj":
+                return "self_attn_q_pre" in atomics
+            if child_name in ("k_proj", "v_proj"):
+                return "self_attn_kv_pre" in atomics
+            return False
+        else:
+            if child_name == "q_proj":
+                return "cross_attn_q_pre" in atomics
+            return False  # cross_attn K,V live in text-embedding space
+
+    def _create_modules(
+        self,
+        dit: nn.Module,
+        cond_emb_dim: int,
+        mlp_dim: int,
+        atomics: Tuple[str, ...],
+        dropout: Optional[float],
+        multiplier: float,
+    ) -> List[LLLiteModuleDiT]:
+        modules: List[LLLiteModuleDiT] = []
+        want_mlp_fc1 = "mlp_fc1_pre" in atomics
+        any_attn = any(a in atomics for a in ("self_attn_q_pre", "self_attn_kv_pre", "cross_attn_q_pre"))
+
+        for name, module in dit.named_modules():
+            if LLM_ADAPTER_NAME in name:
+                continue
+            cls = module.__class__.__name__
+
+            if any_attn and cls == TARGET_ATTENTION_CLASS:
+                # The Anima-block Attention exposes is_selfattn; the LLM-Adapter
+                # Attention does not — skip the latter even if path filter misses.
+                if not hasattr(module, "is_selfattn"):
+                    continue
+                is_self_attn = bool(module.is_selfattn)
+                for child_name, child in module.named_children():
+                    if not isinstance(child, nn.Linear):
+                        continue
+                    if not self._attn_atomic_match(is_self_attn, child_name, atomics):
+                        continue
+                    full_name = f"lllite_dit.{name}.{child_name}".replace(".", "_")
+                    modules.append(
+                        LLLiteModuleDiT(full_name, child, cond_emb_dim, mlp_dim, dropout, multiplier)
+                    )
+
+            elif want_mlp_fc1 and cls == TARGET_MLP_CLASS:
+                child = getattr(module, "layer1", None)
+                if not isinstance(child, nn.Linear):
+                    continue
+                full_name = f"lllite_dit.{name}.layer1".replace(".", "_")
+                modules.append(
+                    LLLiteModuleDiT(full_name, child, cond_emb_dim, mlp_dim, dropout, multiplier)
+                )
+
+        return modules
+
+    def set_cond_image(self, cond_image: Optional[torch.Tensor]):
+        """cond_image: (B, 3, H*16, W*16) in [-1, 1]; ``None`` clears."""
+        if cond_image is None:
+            for m in self.lllite_modules:
+                m.cond_emb = None
+            return
+        cx = self.conditioning1(cond_image)  # (B, S, cond_emb_dim)
+        for m in self.lllite_modules:
+            m.cond_emb = cx
+
+    def clear_cond_image(self):
+        self.set_cond_image(None)
+
+    def set_multiplier(self, multiplier: float):
+        self.multiplier = multiplier
+        for m in self.lllite_modules:
+            m.multiplier = multiplier
+
+    def apply_to(self):
+        for m in self.lllite_modules:
+            m.apply_to()
+
+    def restore(self):
+        for m in self.lllite_modules:
+            m.restore()
+
+
+# ----------------------------------------------------------------------------
+# Save / load (named-key format; legacy lllite_modules.* is rejected)
+# ----------------------------------------------------------------------------
+
+_INTERNAL_MODULES_PREFIX = "lllite_modules."
+_INTERNAL_COND_PREFIX = "conditioning1."
+_INTERNAL_DEPTH_KEY = "depth_embeds"
+_SAVED_COND_PREFIX = "lllite_conditioning1."
+_SAVED_DEPTH_SUFFIX = ".depth_embed"
+
+
+def _from_saved_state_dict(lllite: "ControlNetLLLiteDiT", weights_sd: dict) -> dict:
+    """Rewrite a v2 named-key state dict back to the internal layout."""
+    name_to_idx = {m.lllite_name: i for i, m in enumerate(lllite.lllite_modules)}
+    n_modules = len(name_to_idx)
+    out: dict = {}
+    depth_slices: dict = {}
+
+    for k, v in weights_sd.items():
+        if k.startswith(_SAVED_COND_PREFIX):
+            out[_INTERNAL_COND_PREFIX + k[len(_SAVED_COND_PREFIX):]] = v
+            continue
+        if k.endswith(_SAVED_DEPTH_SUFFIX):
+            name = k[: -len(_SAVED_DEPTH_SUFFIX)]
+            if name in name_to_idx:
+                depth_slices[name_to_idx[name]] = v
+                continue
+        head, dot, tail = k.partition(".")
+        if dot and head in name_to_idx:
+            out[f"{_INTERNAL_MODULES_PREFIX}{name_to_idx[head]}.{tail}"] = v
+            continue
+        out[k] = v
+
+    if depth_slices:
+        missing = [i for i in range(n_modules) if i not in depth_slices]
+        if missing:
+            raise RuntimeError(
+                f"depth_embed slices missing for module idx(es) {missing}"
+            )
+        out[_INTERNAL_DEPTH_KEY] = torch.stack(
+            [depth_slices[i] for i in range(n_modules)], dim=0
+        )
+
+    return out
+
+
+def load_lllite_weights(lllite: ControlNetLLLiteDiT, file: str, strict: bool = False):
+    if os.path.splitext(file)[1] == ".safetensors":
+        from safetensors.torch import load_file
+        weights_sd = load_file(file)
+    else:
+        weights_sd = torch.load(file, map_location="cpu")
+
+    if any(k.startswith(_INTERNAL_MODULES_PREFIX) for k in weights_sd):
+        raise RuntimeError(
+            f"weights at {file} appear to be in a legacy ControlNet-LLLite weight format "
+            f"(keys starting with '{_INTERNAL_MODULES_PREFIX}'). The current code uses a "
+            f"named-key format (per-module key prefix = lllite_name, e.g. "
+            f"'lllite_dit_blocks_0_self_attn_q_proj.down.weight'). Re-train with the current codebase."
+        )
+
+    converted = _from_saved_state_dict(lllite, weights_sd)
+    info = lllite.load_state_dict(converted, strict=strict)
+    logger.info("loaded LLLite weights from %s: %s", file, info)
+    return info
+
+
+def read_lllite_metadata(file: str) -> dict:
+    if os.path.splitext(file)[1] != ".safetensors":
+        return {}
+    from safetensors import safe_open
+    with safe_open(file, framework="pt") as f:
+        meta = f.metadata()
+    return meta or {}

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -1,0 +1,268 @@
+"""
+vsLinx Anima LLLite Tiled ControlNet Sampler
+
+Collapses a whole "tiled upscale with Anima ControlNet-LLLite" graph into a
+single node. Internally it reproduces, for an arbitrary rows x columns grid:
+
+    ImageTile (essentials)              -> split image into overlapping tiles
+    for each tile:
+        AnimaLLLiteApply (Anima-LLLite) -> patch MODEL with the tile as cond
+        VAEEncode                       -> tile -> latent
+        KSampler                        -> sample the tile
+        VAEDecode                       -> latent -> tile image
+    ImageUntile (essentials)            -> feather + stitch the tiles back
+
+Doing it in one node means the grid is dynamic: change ``rows``/``columns`` and
+the node loops the right number of times instead of forcing you to wire up one
+KSampler chain per tile.
+
+This node has no hard dependency on other custom node packs. The Anima
+ControlNet-LLLite apply logic is vendored under ``nodes/_vendor`` (from
+kohya-ss/ComfyUI-Anima-LLLite, Apache 2.0 — see the README "Credits" section),
+and the essentials tile/untile math is small and pure, so it is reimplemented
+here verbatim (algorithm and feathering from comfyui_essentials, MIT).
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+# --- essentials tile/untile math (reimplemented; see module docstring) -------
+
+def _tile_image(image, rows, cols, overlap, overlap_x, overlap_y):
+    """Split ``image`` (B,H,W,C) into a (rows*cols, h, w, C) batch.
+
+    Returns ``(tiles, tile_w_full, tile_h_full, overlap_w, overlap_h)`` where the
+    overlaps are the *computed* (and clamped) values — these must be fed back
+    into :func:`_untile_image` for the geometry to line up. Mirrors
+    ``comfyui_essentials.ImageTile``.
+    """
+    h, w = image.shape[1:3]
+    tile_h = h // rows
+    tile_w = w // cols
+    h = tile_h * rows
+    w = tile_w * cols
+    overlap_h = int(tile_h * overlap) + overlap_y
+    overlap_w = int(tile_w * overlap) + overlap_x
+
+    # max overlap is half of the tile size
+    overlap_h = min(tile_h // 2, overlap_h)
+    overlap_w = min(tile_w // 2, overlap_w)
+
+    if rows == 1:
+        overlap_h = 0
+    if cols == 1:
+        overlap_w = 0
+
+    tiles = []
+    for i in range(rows):
+        for j in range(cols):
+            y1 = i * tile_h
+            x1 = j * tile_w
+
+            if i > 0:
+                y1 -= overlap_h
+            if j > 0:
+                x1 -= overlap_w
+
+            y2 = y1 + tile_h + overlap_h
+            x2 = x1 + tile_w + overlap_w
+
+            if y2 > h:
+                y2 = h
+                y1 = y2 - tile_h - overlap_h
+            if x2 > w:
+                x2 = w
+                x1 = x2 - tile_w - overlap_w
+
+            tiles.append(image[:, y1:y2, x1:x2, :])
+    tiles = torch.cat(tiles, dim=0)
+
+    return tiles, tile_w + overlap_w, tile_h + overlap_h, overlap_w, overlap_h
+
+
+def _untile_image(tiles, overlap_x, overlap_y, rows, cols):
+    """Feather + stitch a (rows*cols, h, w, C) batch back into one image.
+
+    Mirrors ``comfyui_essentials.ImageUntile`` (top/left overlap feathering).
+    """
+    tile_h, tile_w = tiles.shape[1:3]
+    tile_h -= overlap_y
+    tile_w -= overlap_x
+    out_w = cols * tile_w
+    out_h = rows * tile_h
+
+    out = torch.zeros((1, out_h, out_w, tiles.shape[3]), device=tiles.device, dtype=tiles.dtype)
+
+    for i in range(rows):
+        for j in range(cols):
+            y1 = i * tile_h
+            x1 = j * tile_w
+
+            if i > 0:
+                y1 -= overlap_y
+            if j > 0:
+                x1 -= overlap_x
+
+            y2 = y1 + tile_h + overlap_y
+            x2 = x1 + tile_w + overlap_x
+
+            if y2 > out_h:
+                y2 = out_h
+                y1 = y2 - tile_h - overlap_y
+            if x2 > out_w:
+                x2 = out_w
+                x1 = x2 - tile_w - overlap_x
+
+            mask = torch.ones((1, tile_h + overlap_y, tile_w + overlap_x), device=tiles.device, dtype=tiles.dtype)
+
+            # feather the overlap on top
+            if i > 0 and overlap_y > 0:
+                mask[:, :overlap_y, :] *= torch.linspace(0, 1, overlap_y, device=tiles.device, dtype=tiles.dtype).unsqueeze(1)
+            # feather the overlap on left
+            if j > 0 and overlap_x > 0:
+                mask[:, :, :overlap_x] *= torch.linspace(0, 1, overlap_x, device=tiles.device, dtype=tiles.dtype).unsqueeze(0)
+
+            mask = mask.unsqueeze(-1).repeat(1, 1, 1, tiles.shape[3])
+            tile = tiles[i * cols + j] * mask
+            out[:, y1:y2, x1:x2, :] = out[:, y1:y2, x1:x2, :] * (1 - mask) + tile
+    return out
+
+
+def _resize_to(image, target_h, target_w, method):
+    """Resize a (B,H,W,C) image to (target_h, target_w) using ``method``."""
+    import comfy.utils
+
+    if image.shape[1] == target_h and image.shape[2] == target_w:
+        return image
+    s = comfy.utils.common_upscale(image.movedim(-1, 1), target_w, target_h, method, "disabled")
+    return s.movedim(1, -1)
+
+
+class VSLinx_AnimaLLLiteTiledSampler:
+    @classmethod
+    def INPUT_TYPES(cls):
+        # All comfy imports are lazy: this runs at runtime when comfy is loaded.
+        import comfy.samplers
+        import folder_paths
+        from nodes import MAX_RESOLUTION
+
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "model": ("MODEL",),
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "vae": ("VAE",),
+
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
+                "cfg": ("FLOAT", {"default": 7.0, "min": 0.0, "max": 100.0, "step": 0.1, "round": 0.01}),
+                "sampler_name": (comfy.samplers.KSampler.SAMPLERS,),
+                "scheduler": (comfy.samplers.KSampler.SCHEDULERS,),
+                "denoise": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
+
+                "lllite_name": (folder_paths.get_filename_list("controlnet"),
+                                {"tooltip": "Anima ControlNet-LLLite weights file (from the controlnet folder)."}),
+                "strength": ("FLOAT", {"default": 1.0, "min": -10.0, "max": 10.0, "step": 0.01}),
+                "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
+                "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001}),
+                "preserve_wrapper": ("BOOLEAN", {"default": True,
+                    "tooltip": "Delegate to any model_function_wrapper already installed upstream instead of overwriting it, so multiple wrapper nodes can stack. Same toggle as the AnimaLLLiteApply node."}),
+
+                "rows": ("INT", {"default": 2, "min": 1, "max": 256, "step": 1}),
+                "columns": ("INT", {"default": 2, "min": 1, "max": 256, "step": 1}),
+                "overlap": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 0.5, "step": 0.01,
+                    "tooltip": "Overlap between tiles as a fraction of tile size, added on top of overlap_x/overlap_y."}),
+                "overlap_x": ("INT", {"default": 64, "min": 0, "max": MAX_RESOLUTION // 2, "step": 1,
+                    "tooltip": "Extra horizontal overlap in pixels."}),
+                "overlap_y": ("INT", {"default": 64, "min": 0, "max": MAX_RESOLUTION // 2, "step": 1,
+                    "tooltip": "Extra vertical overlap in pixels."}),
+                "method": (["lanczos", "nearest-exact", "bilinear", "area", "bicubic"],
+                    {"tooltip": "Resampling used to keep every decoded tile at a uniform size before stitching."}),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("image",)
+    FUNCTION = "execute"
+    CATEGORY = "vsLinx/sampling"
+    DESCRIPTION = (
+        "All-in-one Anima ControlNet-LLLite tiled sampler. Splits the image into "
+        "a rows x columns grid of overlapping tiles, then for every tile applies "
+        "Anima LLLite (tile as control), VAE-encodes, KSamples and VAE-decodes, "
+        "and finally feathers the tiles back together — replacing a whole manual "
+        "tile/sample/untile graph with one node. No extra node packs required."
+    )
+    SEARCH_ALIASES = [
+        "anima lllite tiled sampler",
+        "anima tile upscale",
+        "lllite tiled controlnet sampling",
+        "tiled ksampler anima",
+        "anima controlnet tile",
+    ]
+
+    def execute(self, image, model, positive, negative, vae,
+                seed, steps, cfg, sampler_name, scheduler, denoise,
+                lllite_name, strength, start_percent, end_percent, preserve_wrapper,
+                rows, columns, overlap, overlap_x, overlap_y, method):
+        import comfy.utils
+        import folder_paths
+        from nodes import VAEEncode, VAEDecode, common_ksampler
+
+        from ._vendor.anima_lllite_apply import apply_anima_lllite
+
+        weights_path = folder_paths.get_full_path("controlnet", lllite_name)
+        if weights_path is None:
+            raise FileNotFoundError(
+                f"LLLite weights '{lllite_name}' not found in the controlnet folder."
+            )
+
+        vae_encoder = VAEEncode()
+        vae_decoder = VAEDecode()
+
+        tiles, tile_w_full, tile_h_full, ov_w, ov_h = _tile_image(
+            image, rows, columns, overlap, overlap_x, overlap_y
+        )
+        num_tiles = tiles.shape[0]
+
+        pbar = comfy.utils.ProgressBar(num_tiles)
+        out_tiles = []
+        for idx in range(num_tiles):
+            tile_img = tiles[idx:idx + 1]
+            th, tw = tile_img.shape[1], tile_img.shape[2]
+
+            # Patch the model so the LLLite control image is this tile.
+            patched_model = apply_anima_lllite(
+                model, weights_path, tile_img, strength,
+                start_percent, end_percent, preserve_wrapper,
+            )
+
+            latent = vae_encoder.encode(vae, tile_img)[0]
+
+            sampled = common_ksampler(
+                patched_model, seed, steps, cfg, sampler_name, scheduler,
+                positive, negative, latent, denoise=denoise,
+            )[0]
+
+            decoded = vae_decoder.decode(vae, sampled)[0]
+
+            # Keep tiles uniform (the VAE may round dims to a multiple of 8) so the
+            # untile geometry and overlaps stay exact.
+            decoded = _resize_to(decoded, th, tw, method)
+            out_tiles.append(decoded)
+            pbar.update(1)
+
+        out_batch = torch.cat(out_tiles, dim=0)
+        result = _untile_image(out_batch, ov_w, ov_h, rows, columns)
+        return (result,)
+
+
+NODE_CLASS_MAPPINGS = {
+    "vsLinx_AnimaLLLiteTiledSampler": VSLinx_AnimaLLLiteTiledSampler,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "vsLinx_AnimaLLLiteTiledSampler": "Anima LLLite Tiled ControlNet Sampler",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: multi-select image loaders (batch/list) and an auto-refreshing last-image loader; image-into-mask-bbox compositing; pixel-art with retro palettes (GameBoy, CGA, NES, Pico-8); exact-factor model upscaling (nearest/bilinear/area/Lanczos); batched VAE Decode/Tiled to cut peak VRAM; an interactive Impact-Pack detailer with per-segment prompts; boolean AND/OR/flip plus bypass/mute nodes driven by a boolean or another node's state; Any to Pipe / Pipe to Any to bundle up to 5 values into one wire; group bookmarks; multiline wildcard text for Impact-Pack; and an rgthree Power LoRA Loader to Image Saver metadata bridge. Also adds settings for model/LoRA hover previews in all loaders (rgthree subdirectory compatible) and a fix for 'Return type mismatch' errors from scheduler-extending nodes like RES4LYF."
-version = "1.10.0"
+version = "1.11.0"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
+++ b/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
@@ -1,0 +1,48 @@
+An all-in-one node for <b>Anima ControlNet-LLLite tiled sampling</b>. It replaces a whole manual graph (image tiling → per-tile VAE encode / LLLite apply / KSampler / VAE decode → batch + untile) with a single node, and makes the grid <b>dynamic</b>: change ``rows``/``columns`` and the node loops the correct number of times instead of forcing you to wire up one sampler chain per tile.
+
+For every tile in the ``rows`` × ``columns`` grid the node:
+1. applies <b>Anima ControlNet-LLLite</b> to the ``model`` using that tile as the control image,
+2. <b>VAE-encodes</b> the tile into a latent,
+3. runs the <b>KSampler</b> on it with the shared ``positive``/``negative`` conditioning,
+4. <b>VAE-decodes</b> the result back to an image tile.
+
+When all tiles are done they are feathered along their overlaps and <b>stitched back</b> into a single image (same algorithm as comfyui_essentials Image Tile / Image Untile). All tiles share the same ``seed``.
+
+<b>No extra node packs are required.</b> The Anima ControlNet-LLLite apply logic is bundled (vendored from <a href="https://github.com/kohya-ss/ComfyUI-Anima-LLLite">kohya-ss/ComfyUI-Anima-LLLite</a>, Apache 2.0), so the node works on its own.
+
+Parameters:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| image | IMAGE | The image to upscale/refine in tiles. |
+| model | MODEL | The Anima diffusion model. Patched per tile with LLLite. |
+| positive | CONDITIONING | Positive conditioning, shared across all tiles. |
+| negative | CONDITIONING | Negative conditioning, shared across all tiles. |
+| vae | VAE | VAE used to encode/decode each tile. |
+| seed | INT | Sampling seed (same for every tile). |
+| steps | INT | KSampler steps. |
+| cfg | FLOAT | Classifier-free guidance scale. |
+| sampler_name | COMBO | KSampler sampler. |
+| scheduler | COMBO | KSampler scheduler. |
+| denoise | FLOAT | Denoise strength — for a tiled upscale this is usually low (e.g. ``0.3``–``0.5``). |
+| lllite_name | COMBO | Anima ControlNet-LLLite weights file (from the ``controlnet`` folder). |
+| strength | FLOAT | LLLite multiplier. |
+| start_percent | FLOAT | Sampling-progress point where LLLite starts acting (0 = from the start). |
+| end_percent | FLOAT | Sampling-progress point where LLLite stops acting (1 = until the end). |
+| preserve_wrapper | BOOLEAN | Delegate to an upstream ``model_function_wrapper`` instead of overwriting it, so multiple wrapper nodes can stack. Same toggle as the AnimaLLLiteApply node. |
+| rows | INT | Number of tile rows. |
+| columns | INT | Number of tile columns. |
+| overlap | FLOAT | Overlap between tiles as a fraction of tile size (added on top of overlap_x/overlap_y). |
+| overlap_x | INT | Extra horizontal overlap in pixels. |
+| overlap_y | INT | Extra vertical overlap in pixels. |
+| method | COMBO | Resampling (``lanczos``, ``nearest-exact``, ``bilinear``, ``area``, ``bicubic``) used to keep every decoded tile at a uniform size before stitching. |
+
+Outputs:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| image | IMAGE | The stitched result of all sampled tiles. |
+
+Notes:
+- Like the essentials Image Tile node, the image is cropped to a whole number of tiles (``columns × tile_width`` by ``rows × tile_height``), so the output can be a few pixels smaller than the input.
+- The overlaps used for stitching are the ones actually computed during tiling (after clamping to at most half a tile), so the geometry always lines up even if ``overlap_x``/``overlap_y`` exceed half the tile size.
+- For lower VRAM use more ``rows``/``columns`` (smaller tiles) rather than a tiled VAE — splitting the VAE pass tends to hurt quality without a meaningful speed gain at these tile sizes.
+- 4-channel (inpaint) LLLite weights are not supported here since they require a per-tile mask; use the standalone AnimaLLLiteApply node for that case.


### PR DESCRIPTION
# feat: Anima LLLite Tiled ControlNet Sampler

## Summary
Adds a single all-in-one node, **Anima LLLite Tiled ControlNet Sampler** (`vsLinx/sampling`), that replaces a whole manual "tiled upscale with Anima ControlNet-LLLite" graph. The grid is **dynamic** — change `rows`/`columns` and the node loops the right number of times instead of forcing you to wire up one KSampler chain per tile.

For each tile in the `rows × columns` grid it:
1. applies **Anima ControlNet-LLLite** to the model using that tile as the control image,
2. **VAE-encodes** the tile,
3. runs the **KSampler** with the shared `positive`/`negative` conditioning,
4. **VAE-decodes** the result,

then feathers the tiles along their overlaps and **stitches** them back into one image (same tiling/feathering math as comfyui_essentials Image Tile / Image Untile). All tiles share the same `seed`.

## No extra dependencies
The Anima ControlNet-LLLite apply logic is **vendored** under `nodes/_vendor/` (from [kohya-ss/ComfyUI-Anima-LLLite](https://github.com/kohya-ss/ComfyUI-Anima-LLLite), Apache 2.0), so the node works standalone without that pack installed. The Apache license is kept alongside the vendored files and attribution is added in a new README **Credits** section (also crediting ltdrdata for Impact-Pack). The essentials tile/untile math is small and pure, so it's reimplemented inline rather than adding a second dependency.

## Inputs
- **Connections:** `image`, `model`, `positive`, `negative`, `vae`
- **Sampler:** `seed`, `steps`, `cfg`, `sampler`, `scheduler`, `denoise`
- **LLLite:** `LLLite Model`, `strength`, `start_percent`, `end_percent`, `preserve_wrapper`
- **Tiling:** `rows`, `columns`, `overlap`, `overlap_x`, `overlap_y`, `method`
- **Output:** stitched `image`

## Notes
- The overlaps used for stitching are the values actually computed during tiling (after clamping to half a tile), so the geometry always lines up.
- Decoded tiles are resized back to their original size with `method` to stay uniform even if the VAE rounds dimensions — keeps the untile geometry exact.
- 4-channel (inpaint) LLLite weights aren't supported here (they need a per-tile mask); use the standalone AnimaLLLiteApply node for that case.
- Licensing: this pack is GPLv3; the vendored Apache 2.0 code is compatible to include, with its notices/license retained.
