### PR TITLE
fix(anima-tiled-sampler): process input batches per-image instead of merging tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.11.1
+- fixed ``Anima LLLite Tiled ControlNet Sampler`` mangling **image batches**: a batch of N images is now tiled, sampled and stitched per-image and returned as a batch of N (previously the tiles of all images were mixed into one morphed result). Batch of 1 and list inputs are unchanged.
+- added an optional per-tile ``color_match`` (``mean_std`` / ``wavelet``, with ``color_match_strength``) to the ``Anima LLLite Tiled ControlNet Sampler``. It re-anchors each tile's colour to its source tile before stitching, fixing tonal seams (faint brightness/colour steps between independently-sampled tiles, most visible on smooth gradients). Default ``none``, so existing graphs are unaffected; it's a pixel-stats pass and adds no extra sampling.
+
 ### v.1.11.0
 - added new ``Anima LLLite Tiled ControlNet Sampler``-Node in the ``vsLinx/sampling`` group. An all-in-one node that tiles an image into a dynamic ``rows`` × ``columns`` grid and, for each tile, applies Anima ControlNet-LLLite (tile as control), VAE-encodes, KSamples and VAE-decodes, then feathers and stitches the tiles back together — replacing a whole manual tile/sample/untile graph with a single node. Exposes the sampler, LLLite and tiling (``overlap``/``overlap_x``/``overlap_y``/``method``) fields, plus a per-tile ``color_match`` (``mean_std``/``wavelet``) that fixes tonal seams between tiles. Needs no extra node packs — the Anima ControlNet-LLLite logic is bundled (vendored from kohya-ss, see Credits).
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ For every tile in the ``rows`` × ``columns`` grid it applies **Anima ControlNet
 
 It exposes the sampler fields (``seed``, ``steps``, ``cfg``, ``sampler``, ``scheduler``, ``denoise``), the LLLite fields (``LLLite Model``, ``strength``, ``start_percent``, ``end_percent``, ``preserve_wrapper``) and the tiling fields (``rows``, ``columns``, ``overlap``, ``overlap_x``, ``overlap_y``, ``method``). The overlaps used for stitching are the ones actually computed during tiling, so the geometry always lines up. For lower VRAM, use more ``rows``/``columns`` (smaller tiles).
 
+An optional ``color_match`` (``mean_std`` or ``wavelet``, with ``color_match_strength``) re-anchors each tile's colour to its source tile, fixing *tonal* seams — the faint brightness/colour steps between independently-sampled tiles, most visible on smooth gradients. ``mean_std`` matches per-channel mean/std; ``wavelet`` keeps the tile's detail but takes the source's broad tone.
+
 **No extra node packs are required** - the Anima ControlNet-LLLite apply logic is bundled (vendored from [kohya-ss/ComfyUI-Anima-LLLite](https://github.com/kohya-ss/ComfyUI-Anima-LLLite), see [Credits](#credits)), so the node works on its own. It can also be found in the node search under terms like ``Anima LLLite Tiled Sampler`` or ``Anima Tile Upscale``.
 
 ### Inpaint helper
@@ -196,7 +198,7 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 
 ## Changelog
 ### v.1.11.0
-- added new ``Anima LLLite Tiled ControlNet Sampler``-Node in the ``vsLinx/sampling`` group. An all-in-one node that tiles an image into a dynamic ``rows`` × ``columns`` grid and, for each tile, applies Anima ControlNet-LLLite (tile as control), VAE-encodes, KSamples and VAE-decodes, then feathers and stitches the tiles back together — replacing a whole manual tile/sample/untile graph with a single node. Exposes the sampler, LLLite and tiling (``overlap``/``overlap_x``/``overlap_y``/``method``) fields. Needs no extra node packs — the Anima ControlNet-LLLite logic is bundled (vendored from kohya-ss, see Credits).
+- added new ``Anima LLLite Tiled ControlNet Sampler``-Node in the ``vsLinx/sampling`` group. An all-in-one node that tiles an image into a dynamic ``rows`` × ``columns`` grid and, for each tile, applies Anima ControlNet-LLLite (tile as control), VAE-encodes, KSamples and VAE-decodes, then feathers and stitches the tiles back together — replacing a whole manual tile/sample/untile graph with a single node. Exposes the sampler, LLLite and tiling (``overlap``/``overlap_x``/``overlap_y``/``method``) fields, plus a per-tile ``color_match`` (``mean_std``/``wavelet``) that fixes tonal seams between tiles. Needs no extra node packs — the Anima ControlNet-LLLite logic is bundled (vendored from kohya-ss, see Credits).
 
 ### v.1.10.0
 - added new ``Forward/Bypass-Mute on State (Any)``-Node in the ``vsLinx/utility`` group. Forwards any value while mirroring the bypass/mute state of the node connected to its ``trigger`` input onto the directly connected downstream node(s) (bypass → bypass, mute → mute, normal → normal). Includes an ``Ignore subgraph boundary`` toggle to follow the trigger across subgraph boundaries until a real node, and a ``Mirror this node's own bypass/mute`` toggle to also propagate this node's own state downstream.

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -321,10 +321,10 @@ class VSLinx_AnimaLLLiteTiledSampler:
             out_tiles = []
             for idx in range(tiles.shape[0]):
                 tile_img = tiles[idx:idx + 1]
-                th, tw = tile_img.shape[1], tile_img.shape[2]
-                # Keep tiles uniform (the VAE may round dims to a multiple of 8)
-                # so the untile geometry and overlaps stay exact.
-                decoded = _resize_to(sample_region(tile_img, denoise), th, tw, method)
+                # sample_region already returns the tile at its original size
+                # (it resizes internally), keeping the untile geometry exact even
+                # if the VAE rounds dims to a multiple of 8.
+                decoded = sample_region(tile_img, denoise)
                 # Re-anchor each tile's colour to its source so tiles can't drift
                 # in tone relative to each other (fixes tonal seams).
                 decoded = color_correct(decoded, tile_img)

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -26,6 +26,7 @@ here verbatim (algorithm and feathering from comfyui_essentials, MIT).
 from __future__ import annotations
 
 import torch
+import torch.nn.functional as F
 
 
 # --- essentials tile/untile math (reimplemented; see module docstring) -------
@@ -140,6 +141,55 @@ def _resize_to(image, target_h, target_w, method):
     return s.movedim(1, -1)
 
 
+# --- per-tile color matching (fixes tonal seams between independent tiles) ----
+
+def _color_match_meanstd(target, ref):
+    """Reinhard mean/std transfer: re-scale ``target``'s per-channel mean and std
+    to match ``ref``. Both are (1, H, W, C) in [0, 1]."""
+    dims = (1, 2)
+    t_mean = target.mean(dim=dims, keepdim=True)
+    t_std = target.std(dim=dims, keepdim=True)
+    r_mean = ref.mean(dim=dims, keepdim=True)
+    r_std = ref.std(dim=dims, keepdim=True)
+    return (target - t_mean) / (t_std + 1e-5) * r_std + r_mean
+
+
+def _gaussian_blur(img_bchw, radius):
+    """Separable gaussian blur (sigma = radius), reflect-padded."""
+    x = torch.arange(-radius, radius + 1, device=img_bchw.device, dtype=img_bchw.dtype)
+    k1 = torch.exp(-(x * x) / (2.0 * radius * radius))
+    k1 = k1 / k1.sum()
+    c = img_bchw.shape[1]
+    kh = k1.view(1, 1, 1, -1).repeat(c, 1, 1, 1)
+    kv = k1.view(1, 1, -1, 1).repeat(c, 1, 1, 1)
+    out = F.pad(img_bchw, (radius, radius, 0, 0), mode="reflect")
+    out = F.conv2d(out, kh, groups=c)
+    out = F.pad(out, (0, 0, radius, radius), mode="reflect")
+    out = F.conv2d(out, kv, groups=c)
+    return out
+
+
+def _wavelet_decompose(img_bchw, levels=5):
+    """Split into (high-frequency detail, low-frequency tone) via a gaussian pyramid."""
+    high = torch.zeros_like(img_bchw)
+    low = img_bchw
+    for i in range(levels):
+        blurred = _gaussian_blur(low, 2 ** i)
+        high = high + (low - blurred)
+        low = blurred
+    return high, low
+
+
+def _color_match_wavelet(target, ref):
+    """Keep ``target``'s detail (high freq) but take ``ref``'s tone (low freq).
+    Both are (1, H, W, C) in [0, 1]."""
+    t = target.movedim(-1, 1)
+    r = ref.movedim(-1, 1)
+    t_high, _ = _wavelet_decompose(t)
+    _, r_low = _wavelet_decompose(r)
+    return (t_high + r_low).movedim(1, -1)
+
+
 class VSLinx_AnimaLLLiteTiledSampler:
     @classmethod
     def INPUT_TYPES(cls):
@@ -181,6 +231,11 @@ class VSLinx_AnimaLLLiteTiledSampler:
                     "tooltip": "Extra vertical overlap in pixels."}),
                 "method": (["lanczos", "nearest-exact", "bilinear", "area", "bicubic"],
                     {"tooltip": "Resampling used to keep every decoded tile at a uniform size before stitching."}),
+
+                "color_match": (["none", "mean_std", "wavelet"],
+                    {"tooltip": "Per-tile color matching against the source tile, to fix tonal seams (brightness/colour steps between tiles). 'mean_std' re-scales each tile's per-channel mean/std (fast, simple); 'wavelet' keeps the tile's detail but takes the source tile's broad tone (better on textured tiles)."}),
+                "color_match_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01,
+                    "tooltip": "How strongly to apply the color match (0 = off, 1 = full)."}),
             },
         }
 
@@ -206,7 +261,8 @@ class VSLinx_AnimaLLLiteTiledSampler:
     def execute(self, image, model, positive, negative, vae,
                 seed, steps, cfg, sampler_name, scheduler, denoise,
                 lllite_name, strength, start_percent, end_percent, preserve_wrapper,
-                rows, columns, overlap, overlap_x, overlap_y, method):
+                rows, columns, overlap, overlap_x, overlap_y, method,
+                color_match="none", color_match_strength=1.0):
         import comfy.utils
         import folder_paths
         from nodes import VAEEncode, VAEDecode, common_ksampler
@@ -221,6 +277,34 @@ class VSLinx_AnimaLLLiteTiledSampler:
 
         vae_encoder = VAEEncode()
         vae_decoder = VAEDecode()
+
+        def color_correct(target, ref):
+            """Match ``target``'s colour to source ``ref`` per the selected mode."""
+            if color_match == "none":
+                return target
+            if color_match == "mean_std":
+                matched = _color_match_meanstd(target, ref)
+            else:
+                matched = _color_match_wavelet(target, ref)
+            matched = matched.clamp(0.0, 1.0)
+            if color_match_strength >= 1.0:
+                return matched
+            return target * (1.0 - color_match_strength) + matched * color_match_strength
+
+        def sample_region(region_img, region_denoise):
+            """LLLite-patched img2img over one region; returns the decoded image."""
+            rh, rw = region_img.shape[1], region_img.shape[2]
+            patched_model = apply_anima_lllite(
+                model, weights_path, region_img, strength,
+                start_percent, end_percent, preserve_wrapper,
+            )
+            latent = vae_encoder.encode(vae, region_img)[0]
+            sampled = common_ksampler(
+                patched_model, seed, steps, cfg, sampler_name, scheduler,
+                positive, negative, latent, denoise=region_denoise,
+            )[0]
+            decoded = vae_decoder.decode(vae, sampled)[0]
+            return _resize_to(decoded, rh, rw, method)
 
         # Process each image of an input batch independently and stitch each one
         # back on its own, so a batch of N images comes out as a batch of N
@@ -238,30 +322,18 @@ class VSLinx_AnimaLLLiteTiledSampler:
             for idx in range(tiles.shape[0]):
                 tile_img = tiles[idx:idx + 1]
                 th, tw = tile_img.shape[1], tile_img.shape[2]
-
-                # Patch the model so the LLLite control image is this tile.
-                patched_model = apply_anima_lllite(
-                    model, weights_path, tile_img, strength,
-                    start_percent, end_percent, preserve_wrapper,
-                )
-
-                latent = vae_encoder.encode(vae, tile_img)[0]
-
-                sampled = common_ksampler(
-                    patched_model, seed, steps, cfg, sampler_name, scheduler,
-                    positive, negative, latent, denoise=denoise,
-                )[0]
-
-                decoded = vae_decoder.decode(vae, sampled)[0]
-
-                # Keep tiles uniform (the VAE may round dims to a multiple of 8) so
-                # the untile geometry and overlaps stay exact.
-                decoded = _resize_to(decoded, th, tw, method)
+                # Keep tiles uniform (the VAE may round dims to a multiple of 8)
+                # so the untile geometry and overlaps stay exact.
+                decoded = _resize_to(sample_region(tile_img, denoise), th, tw, method)
+                # Re-anchor each tile's colour to its source so tiles can't drift
+                # in tone relative to each other (fixes tonal seams).
+                decoded = color_correct(decoded, tile_img)
                 out_tiles.append(decoded)
                 pbar.update(1)
 
-            out_batch = torch.cat(out_tiles, dim=0)
-            results.append(_untile_image(out_batch, ov_w, ov_h, rows, columns))
+            results.append(_untile_image(
+                torch.cat(out_tiles, dim=0), ov_w, ov_h, rows, columns
+            ))
 
         return (torch.cat(results, dim=0),)
 

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -222,41 +222,48 @@ class VSLinx_AnimaLLLiteTiledSampler:
         vae_encoder = VAEEncode()
         vae_decoder = VAEDecode()
 
-        tiles, tile_w_full, tile_h_full, ov_w, ov_h = _tile_image(
-            image, rows, columns, overlap, overlap_x, overlap_y
-        )
-        num_tiles = tiles.shape[0]
+        # Process each image of an input batch independently and stitch each one
+        # back on its own, so a batch of N images comes out as a batch of N
+        # results (without this the tiles of different images would be mixed).
+        batch_size = image.shape[0]
+        pbar = comfy.utils.ProgressBar(batch_size * rows * columns)
 
-        pbar = comfy.utils.ProgressBar(num_tiles)
-        out_tiles = []
-        for idx in range(num_tiles):
-            tile_img = tiles[idx:idx + 1]
-            th, tw = tile_img.shape[1], tile_img.shape[2]
-
-            # Patch the model so the LLLite control image is this tile.
-            patched_model = apply_anima_lllite(
-                model, weights_path, tile_img, strength,
-                start_percent, end_percent, preserve_wrapper,
+        results = []
+        for b in range(batch_size):
+            tiles, tile_w_full, tile_h_full, ov_w, ov_h = _tile_image(
+                image[b:b + 1], rows, columns, overlap, overlap_x, overlap_y
             )
 
-            latent = vae_encoder.encode(vae, tile_img)[0]
+            out_tiles = []
+            for idx in range(tiles.shape[0]):
+                tile_img = tiles[idx:idx + 1]
+                th, tw = tile_img.shape[1], tile_img.shape[2]
 
-            sampled = common_ksampler(
-                patched_model, seed, steps, cfg, sampler_name, scheduler,
-                positive, negative, latent, denoise=denoise,
-            )[0]
+                # Patch the model so the LLLite control image is this tile.
+                patched_model = apply_anima_lllite(
+                    model, weights_path, tile_img, strength,
+                    start_percent, end_percent, preserve_wrapper,
+                )
 
-            decoded = vae_decoder.decode(vae, sampled)[0]
+                latent = vae_encoder.encode(vae, tile_img)[0]
 
-            # Keep tiles uniform (the VAE may round dims to a multiple of 8) so the
-            # untile geometry and overlaps stay exact.
-            decoded = _resize_to(decoded, th, tw, method)
-            out_tiles.append(decoded)
-            pbar.update(1)
+                sampled = common_ksampler(
+                    patched_model, seed, steps, cfg, sampler_name, scheduler,
+                    positive, negative, latent, denoise=denoise,
+                )[0]
 
-        out_batch = torch.cat(out_tiles, dim=0)
-        result = _untile_image(out_batch, ov_w, ov_h, rows, columns)
-        return (result,)
+                decoded = vae_decoder.decode(vae, sampled)[0]
+
+                # Keep tiles uniform (the VAE may round dims to a multiple of 8) so
+                # the untile geometry and overlaps stay exact.
+                decoded = _resize_to(decoded, th, tw, method)
+                out_tiles.append(decoded)
+                pbar.update(1)
+
+            out_batch = torch.cat(out_tiles, dim=0)
+            results.append(_untile_image(out_batch, ov_w, ov_h, rows, columns))
+
+        return (torch.cat(results, dim=0),)
 
 
 NODE_CLASS_MAPPINGS = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: multi-select image loaders (batch/list) and an auto-refreshing last-image loader; image-into-mask-bbox compositing; pixel-art with retro palettes (GameBoy, CGA, NES, Pico-8); exact-factor model upscaling (nearest/bilinear/area/Lanczos); batched VAE Decode/Tiled to cut peak VRAM; an interactive Impact-Pack detailer with per-segment prompts; boolean AND/OR/flip plus bypass/mute nodes driven by a boolean or another node's state; Any to Pipe / Pipe to Any to bundle up to 5 values into one wire; group bookmarks; multiline wildcard text for Impact-Pack; and an rgthree Power LoRA Loader to Image Saver metadata bridge. Also adds settings for model/LoRA hover previews in all loaders (rgthree subdirectory compatible) and a fix for 'Return type mismatch' errors from scheduler-extending nodes like RES4LYF."
-version = "1.11.0"
+version = "1.11.1"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
+++ b/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
@@ -35,6 +35,8 @@ Parameters:
 | overlap_x | INT | Extra horizontal overlap in pixels. |
 | overlap_y | INT | Extra vertical overlap in pixels. |
 | method | COMBO | Resampling (``lanczos``, ``nearest-exact``, ``bilinear``, ``area``, ``bicubic``) used to keep every decoded tile at a uniform size before stitching. |
+| color_match | COMBO | Per-tile color matching against the source tile, to fix tonal seams (brightness/colour steps between tiles). ``none`` (default), ``mean_std`` (re-scales each tile's per-channel mean/std — fast, simple), ``wavelet`` (keeps the tile's detail but takes the source tile's broad tone — better on textured tiles). |
+| color_match_strength | FLOAT | How strongly to apply the color match (``0`` = off, ``1`` = full). |
 
 Outputs:
 | Parameter | Type | Description |
@@ -45,4 +47,5 @@ Notes:
 - Like the essentials Image Tile node, the image is cropped to a whole number of tiles (``columns × tile_width`` by ``rows × tile_height``), so the output can be a few pixels smaller than the input.
 - The overlaps used for stitching are the ones actually computed during tiling (after clamping to at most half a tile), so the geometry always lines up even if ``overlap_x``/``overlap_y`` exceed half the tile size.
 - For lower VRAM use more ``rows``/``columns`` (smaller tiles) rather than a tiled VAE — splitting the VAE pass tends to hurt quality without a meaningful speed gain at these tile sizes.
+- Tiles sampled independently can drift in overall tone, leaving a faint brightness/colour step (seam) across smooth areas — most visible on gradients like skin or sky. ``color_match`` re-anchors each tile's colour to its source tile so the tones stay consistent and the step disappears.
 - 4-channel (inpaint) LLLite weights are not supported here since they require a per-tile mask; use the standalone AnimaLLLiteApply node for that case.


### PR DESCRIPTION
# Anima LLLite Tiled Sampler: batch handling + per-tile color match

## Summary
Two improvements to the **Anima LLLite Tiled ControlNet Sampler** node:

1. **Batch handling** — the node now processes input batches correctly.
2. **Per-tile color match** — an optional pass that removes tonal seams between tiles.

## 1. Batch handling (bug fix)
Previously the node assumed a single image. Passing a **batch** of N images (e.g. several picks from cg-image-filter) merged them into one morphed result, because the tiling stacked *tiles × batch-images* along one dimension and the untile only read the first `rows × columns` slices — stitching one image out of pieces of all of them. (A *list* of images worked, since ComfyUI calls the node once per item.)

Now each image in the batch is tiled, sampled and stitched **independently**, then the results are concatenated back into an output batch:
- Batch of N → batch of N (fixed)
- Batch of 1 → identical to before
- List input → unchanged (still one call per item)

All images in a batch share the same seed/conditioning/settings, consistent with the prior single-image behaviour.

## 2. Per-tile color match (new, optional)
Because each tile is an independent diffusion, neighbouring tiles can drift in overall tone, leaving a faint brightness/colour **step** across smooth areas (e.g. skin, sky). Plain overlap-blending can't remove this — a wide overlap just spreads the step into a gradient.

The new `color_match` re-anchors each decoded tile's colour to its **source tile** before stitching, so tiles can't drift relative to each other:

- `color_match`: `none` (default) / `mean_std` / `wavelet`
  - **mean_std** — Reinhard per-channel mean/std transfer (fast, simple)
  - **wavelet** — keeps the tile's high-frequency detail but takes the source's low-frequency tone (better on textured tiles)
- `color_match_strength`: `0`–`1` blend (default `1.0`)

Default is `none`, so existing graphs are unaffected. It's a cheap pixel-stats operation — no extra diffusion passes.
