### PR TITLE
feat(anima-tiled-sampler): add multidiffusion sampling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.11.1
+- fixed ``Anima LLLite Tiled ControlNet Sampler`` mangling **image batches**: a batch of N images is now tiled, sampled and stitched per-image and returned as a batch of N (previously the tiles of all images were mixed into one morphed result). Batch of 1 and list inputs are unchanged.
+- added an optional per-tile ``color_match`` (``mean_std`` / ``wavelet``, with ``color_match_strength``) to the ``Anima LLLite Tiled ControlNet Sampler``. It re-anchors each tile's colour to its source tile before stitching, fixing tonal seams (faint brightness/colour steps between independently-sampled tiles, most visible on smooth gradients). Default ``none``, so existing graphs are unaffected; it's a pixel-stats pass and adds no extra sampling.
+
 ### v.1.11.0
 - added new ``Anima LLLite Tiled ControlNet Sampler``-Node in the ``vsLinx/sampling`` group. An all-in-one node that tiles an image into a dynamic ``rows`` × ``columns`` grid and, for each tile, applies Anima ControlNet-LLLite (tile as control), VAE-encodes, KSamples and VAE-decodes, then feathers and stitches the tiles back together — replacing a whole manual tile/sample/untile graph with a single node. Exposes the sampler, LLLite and tiling (``overlap``/``overlap_x``/``overlap_y``/``method``) fields, plus a per-tile ``color_match`` (``mean_std``/``wavelet``) that fixes tonal seams between tiles. Needs no extra node packs — the Anima ControlNet-LLLite logic is bundled (vendored from kohya-ss, see Credits).
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ For every tile in the ``rows`` × ``columns`` grid it applies **Anima ControlNet
 
 It exposes the sampler fields (``seed``, ``steps``, ``cfg``, ``sampler``, ``scheduler``, ``denoise``), the LLLite fields (``LLLite Model``, ``strength``, ``start_percent``, ``end_percent``, ``preserve_wrapper``) and the tiling fields (``rows``, ``columns``, ``overlap``, ``overlap_x``, ``overlap_y``, ``method``). The overlaps used for stitching are the ones actually computed during tiling, so the geometry always lines up. For lower VRAM, use more ``rows``/``columns`` (smaller tiles).
 
+An optional ``color_match`` (``mean_std`` or ``wavelet``, with ``color_match_strength``) re-anchors each tile's colour to its source tile, fixing *tonal* seams — the faint brightness/colour steps between independently-sampled tiles, most visible on smooth gradients. ``mean_std`` matches per-channel mean/std; ``wavelet`` keeps the tile's detail but takes the source's broad tone.
+
 **No extra node packs are required** - the Anima ControlNet-LLLite apply logic is bundled (vendored from [kohya-ss/ComfyUI-Anima-LLLite](https://github.com/kohya-ss/ComfyUI-Anima-LLLite), see [Credits](#credits)), so the node works on its own. It can also be found in the node search under terms like ``Anima LLLite Tiled Sampler`` or ``Anima Tile Upscale``.
 
 ### Inpaint helper
@@ -196,7 +198,7 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 
 ## Changelog
 ### v.1.11.0
-- added new ``Anima LLLite Tiled ControlNet Sampler``-Node in the ``vsLinx/sampling`` group. An all-in-one node that tiles an image into a dynamic ``rows`` × ``columns`` grid and, for each tile, applies Anima ControlNet-LLLite (tile as control), VAE-encodes, KSamples and VAE-decodes, then feathers and stitches the tiles back together — replacing a whole manual tile/sample/untile graph with a single node. Exposes the sampler, LLLite and tiling (``overlap``/``overlap_x``/``overlap_y``/``method``) fields. Needs no extra node packs — the Anima ControlNet-LLLite logic is bundled (vendored from kohya-ss, see Credits).
+- added new ``Anima LLLite Tiled ControlNet Sampler``-Node in the ``vsLinx/sampling`` group. An all-in-one node that tiles an image into a dynamic ``rows`` × ``columns`` grid and, for each tile, applies Anima ControlNet-LLLite (tile as control), VAE-encodes, KSamples and VAE-decodes, then feathers and stitches the tiles back together — replacing a whole manual tile/sample/untile graph with a single node. Exposes the sampler, LLLite and tiling (``overlap``/``overlap_x``/``overlap_y``/``method``) fields, plus a per-tile ``color_match`` (``mean_std``/``wavelet``) that fixes tonal seams between tiles. Needs no extra node packs — the Anima ControlNet-LLLite logic is bundled (vendored from kohya-ss, see Credits).
 
 ### v.1.10.0
 - added new ``Forward/Bypass-Mute on State (Any)``-Node in the ``vsLinx/utility`` group. Forwards any value while mirroring the bypass/mute state of the node connected to its ``trigger`` input onto the directly connected downstream node(s) (bypass → bypass, mute → mute, normal → normal). Includes an ``Ignore subgraph boundary`` toggle to follow the trigger across subgraph boundaries until a real node, and a ``Mirror this node's own bypass/mute`` toggle to also propagate this node's own state downstream.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ For every tile in the ``rows`` × ``columns`` grid it applies **Anima ControlNet
 
 It exposes the sampler fields (``seed``, ``steps``, ``cfg``, ``sampler``, ``scheduler``, ``denoise``), the LLLite fields (``LLLite Model``, ``strength``, ``start_percent``, ``end_percent``, ``preserve_wrapper``) and the tiling fields (``rows``, ``columns``, ``overlap``, ``overlap_x``, ``overlap_y``, ``method``). The overlaps used for stitching are the ones actually computed during tiling, so the geometry always lines up. For lower VRAM, use more ``rows``/``columns`` (smaller tiles).
 
-An optional ``color_match`` (``mean_std`` or ``wavelet``, with ``color_match_strength``) re-anchors each tile's colour to its source tile, fixing *tonal* seams — the faint brightness/colour steps between independently-sampled tiles, most visible on smooth gradients. ``mean_std`` matches per-channel mean/std; ``wavelet`` keeps the tile's detail but takes the source's broad tone.
+It has two ``sampling_mode``s:
+- **``per_tile``** (default) — sample each tile to completion, then stitch. Lowest VRAM. Because tiles are sampled independently they can show seams or "double-exposure" ghosting; the optional ``color_match`` (``mean_std`` / ``wavelet``, with ``color_match_strength``) re-anchors each tile's colour to its source tile to fix *tonal* seams (brightness/colour steps), but it can't fully remove structural disagreement.
+- **``multidiffusion``** — a single sampling pass over the whole image that splits the latent into overlapping tiles every denoising step, runs the model per tile (each with its own LLLite control crop), and averages the overlaps in latent space. The tiles are re-synced every step so they can't diverge — seams and double-exposure are eliminated. Uses a little more VRAM (it holds the full latent), and ``method`` / ``color_match`` don't apply.
 
 **No extra node packs are required** - the Anima ControlNet-LLLite apply logic is bundled (vendored from [kohya-ss/ComfyUI-Anima-LLLite](https://github.com/kohya-ss/ComfyUI-Anima-LLLite), see [Credits](#credits)), so the node works on its own. It can also be found in the node search under terms like ``Anima LLLite Tiled Sampler`` or ``Anima Tile Upscale``.
 
@@ -197,6 +199,9 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.12.0
+- added a ``sampling_mode`` to the ``Anima LLLite Tiled ControlNet Sampler``: the new ``multidiffusion`` mode runs a single sampling pass over the whole image, splitting the latent into overlapping tiles each denoising step, applying LLLite per tile and averaging the overlaps in latent space. Because the tiles are re-synced every step they can't diverge, eliminating the tile seams and "double-exposure" ghosting that the ``per_tile`` mode (still the default) can produce. Uses slightly more VRAM (holds the full latent; the VAE auto-tiles if needed); ``method``/``color_match`` don't apply in this mode.
+
 ### v.1.11.1
 - fixed ``Anima LLLite Tiled ControlNet Sampler`` mangling **image batches**: a batch of N images is now tiled, sampled and stitched per-image and returned as a batch of N (previously the tiles of all images were mixed into one morphed result). Batch of 1 and list inputs are unchanged.
 - added an optional per-tile ``color_match`` (``mean_std`` / ``wavelet``, with ``color_match_strength``) to the ``Anima LLLite Tiled ControlNet Sampler``. It re-anchors each tile's colour to its source tile before stitching, fixing tonal seams (faint brightness/colour steps between independently-sampled tiles, most visible on smooth gradients). Default ``none``, so existing graphs are unaffected; it's a pixel-stats pass and adds no extra sampling.

--- a/nodes/_vendor/anima_lllite_apply.py
+++ b/nodes/_vendor/anima_lllite_apply.py
@@ -106,18 +106,21 @@ def _build_inpaint_cond_image(rgb_pm1: torch.Tensor, mask01: torch.Tensor,
     return torch.cat([rgb_pm1, mask_pm1], dim=1)
 
 
-def apply_anima_lllite(model, weights_path: str, image: torch.Tensor, strength: float,
-                       start_percent: float, end_percent: float,
-                       preserve_wrapper: bool = True, mask: Optional[torch.Tensor] = None):
-    """Patch ``model`` with Anima ControlNet-LLLite and return the patched clone.
+# Public alias so callers (e.g. the MultiDiffusion sampler) can preprocess a
+# cond image to a given latent resolution without reaching for a private name.
+prepare_cond_image = _prepare_cond_image
 
-    ``weights_path`` is the resolved path to the LLLite ``.safetensors`` file.
+
+def build_anima_lllite(model, weights_path: str, strength: float):
+    """Build + load a ``ControlNetLLLiteDiT`` from the weights' metadata.
+
+    Returns ``(lllite, patch_spatial, cond_in_channels, inpaint_masked_input)``.
+    Does not clone the model or install a wrapper — the caller drives the lllite
+    object (``set_cond_image`` / ``apply_to`` / ``restore``) however it needs.
     """
     if weights_path is None or not os.path.isfile(weights_path):
         raise FileNotFoundError(f"LLLite weights not found: {weights_path}")
 
-    # Architecture is fully determined by the trained weights — read everything
-    # from metadata rather than exposing knobs that would just cause load errors.
     meta = read_lllite_metadata(weights_path)
     ce_dim = int(meta.get("lllite.cond_emb_dim", 32))
     m_dim = int(meta.get("lllite.mlp_dim", 64))
@@ -132,19 +135,6 @@ def apply_anima_lllite(model, weights_path: str, image: torch.Tensor, strength: 
         aspp_dilations = ASPP_DEFAULT_DILATIONS
     cond_in_channels = int(meta.get("lllite.cond_in_channels", 3))
     inpaint_masked_input = str(meta.get("lllite.inpaint_masked_input", "false")).lower() == "true"
-
-    # Mask / cond_in_channels consistency: 4ch weights need a MASK, 3ch ignore it.
-    if cond_in_channels == 4 and mask is None:
-        raise ValueError(
-            f"LLLite weights '{os.path.basename(weights_path)}' were trained with "
-            f"cond_in_channels=4 (inpaint mode) and require a MASK input."
-        )
-    if cond_in_channels != 4 and mask is not None:
-        logger.warning(
-            "LLLite weights '%s' are %dch; the provided MASK input will be ignored.",
-            os.path.basename(weights_path), cond_in_channels,
-        )
-        mask = None
 
     dit = _get_inner_dit(model)
     patch_spatial = int(getattr(dit, "patch_spatial", 2))
@@ -163,6 +153,37 @@ def apply_anima_lllite(model, weights_path: str, image: torch.Tensor, strength: 
     )
     load_lllite_weights(lllite, weights_path, strict=False)
     lllite.eval().requires_grad_(False)
+    return lllite, patch_spatial, cond_in_channels, inpaint_masked_input
+
+
+def apply_anima_lllite(model, weights_path: str, image: torch.Tensor, strength: float,
+                       start_percent: float, end_percent: float,
+                       preserve_wrapper: bool = True, mask: Optional[torch.Tensor] = None):
+    """Patch ``model`` with Anima ControlNet-LLLite and return the patched clone.
+
+    ``weights_path`` is the resolved path to the LLLite ``.safetensors`` file.
+    """
+    if weights_path is None or not os.path.isfile(weights_path):
+        raise FileNotFoundError(f"LLLite weights not found: {weights_path}")
+
+    # Architecture is fully determined by the trained weights — read everything
+    # from metadata rather than exposing knobs that would just cause load errors.
+    lllite, patch_spatial, cond_in_channels, inpaint_masked_input = build_anima_lllite(
+        model, weights_path, strength
+    )
+
+    # Mask / cond_in_channels consistency: 4ch weights need a MASK, 3ch ignore it.
+    if cond_in_channels == 4 and mask is None:
+        raise ValueError(
+            f"LLLite weights '{os.path.basename(weights_path)}' were trained with "
+            f"cond_in_channels=4 (inpaint mode) and require a MASK input."
+        )
+    if cond_in_channels != 4 and mask is not None:
+        logger.warning(
+            "LLLite weights '%s' are %dch; the provided MASK input will be ignored.",
+            os.path.basename(weights_path), cond_in_channels,
+        )
+        mask = None
 
     # Convert percent range -> sigma range (start_percent=0 → sigma_max).
     model_sampling = model.get_model_object("model_sampling")

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -321,10 +321,10 @@ class VSLinx_AnimaLLLiteTiledSampler:
             out_tiles = []
             for idx in range(tiles.shape[0]):
                 tile_img = tiles[idx:idx + 1]
-                th, tw = tile_img.shape[1], tile_img.shape[2]
-                # Keep tiles uniform (the VAE may round dims to a multiple of 8)
-                # so the untile geometry and overlaps stay exact.
-                decoded = _resize_to(sample_region(tile_img, denoise), th, tw, method)
+                # sample_region already returns the tile at its original size
+                # (it resizes internally), keeping the untile geometry exact even
+                # if the VAE rounds dims to a multiple of 8.
+                decoded = sample_region(tile_img, denoise)
                 # Re-anchor each tile's colour to its source so tiles can't drift
                 # in tone relative to each other (fixes tonal seams).
                 decoded = color_correct(decoded, tile_img)

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -26,6 +26,7 @@ here verbatim (algorithm and feathering from comfyui_essentials, MIT).
 from __future__ import annotations
 
 import torch
+import torch.nn.functional as F
 
 
 # --- essentials tile/untile math (reimplemented; see module docstring) -------
@@ -140,6 +141,55 @@ def _resize_to(image, target_h, target_w, method):
     return s.movedim(1, -1)
 
 
+# --- per-tile color matching (fixes tonal seams between independent tiles) ----
+
+def _color_match_meanstd(target, ref):
+    """Reinhard mean/std transfer: re-scale ``target``'s per-channel mean and std
+    to match ``ref``. Both are (1, H, W, C) in [0, 1]."""
+    dims = (1, 2)
+    t_mean = target.mean(dim=dims, keepdim=True)
+    t_std = target.std(dim=dims, keepdim=True)
+    r_mean = ref.mean(dim=dims, keepdim=True)
+    r_std = ref.std(dim=dims, keepdim=True)
+    return (target - t_mean) / (t_std + 1e-5) * r_std + r_mean
+
+
+def _gaussian_blur(img_bchw, radius):
+    """Separable gaussian blur (sigma = radius), reflect-padded."""
+    x = torch.arange(-radius, radius + 1, device=img_bchw.device, dtype=img_bchw.dtype)
+    k1 = torch.exp(-(x * x) / (2.0 * radius * radius))
+    k1 = k1 / k1.sum()
+    c = img_bchw.shape[1]
+    kh = k1.view(1, 1, 1, -1).repeat(c, 1, 1, 1)
+    kv = k1.view(1, 1, -1, 1).repeat(c, 1, 1, 1)
+    out = F.pad(img_bchw, (radius, radius, 0, 0), mode="reflect")
+    out = F.conv2d(out, kh, groups=c)
+    out = F.pad(out, (0, 0, radius, radius), mode="reflect")
+    out = F.conv2d(out, kv, groups=c)
+    return out
+
+
+def _wavelet_decompose(img_bchw, levels=5):
+    """Split into (high-frequency detail, low-frequency tone) via a gaussian pyramid."""
+    high = torch.zeros_like(img_bchw)
+    low = img_bchw
+    for i in range(levels):
+        blurred = _gaussian_blur(low, 2 ** i)
+        high = high + (low - blurred)
+        low = blurred
+    return high, low
+
+
+def _color_match_wavelet(target, ref):
+    """Keep ``target``'s detail (high freq) but take ``ref``'s tone (low freq).
+    Both are (1, H, W, C) in [0, 1]."""
+    t = target.movedim(-1, 1)
+    r = ref.movedim(-1, 1)
+    t_high, _ = _wavelet_decompose(t)
+    _, r_low = _wavelet_decompose(r)
+    return (t_high + r_low).movedim(1, -1)
+
+
 class VSLinx_AnimaLLLiteTiledSampler:
     @classmethod
     def INPUT_TYPES(cls):
@@ -181,6 +231,11 @@ class VSLinx_AnimaLLLiteTiledSampler:
                     "tooltip": "Extra vertical overlap in pixels."}),
                 "method": (["lanczos", "nearest-exact", "bilinear", "area", "bicubic"],
                     {"tooltip": "Resampling used to keep every decoded tile at a uniform size before stitching."}),
+
+                "color_match": (["none", "mean_std", "wavelet"],
+                    {"tooltip": "Per-tile color matching against the source tile, to fix tonal seams (brightness/colour steps between tiles). 'mean_std' re-scales each tile's per-channel mean/std (fast, simple); 'wavelet' keeps the tile's detail but takes the source tile's broad tone (better on textured tiles)."}),
+                "color_match_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01,
+                    "tooltip": "How strongly to apply the color match (0 = off, 1 = full)."}),
             },
         }
 
@@ -206,7 +261,8 @@ class VSLinx_AnimaLLLiteTiledSampler:
     def execute(self, image, model, positive, negative, vae,
                 seed, steps, cfg, sampler_name, scheduler, denoise,
                 lllite_name, strength, start_percent, end_percent, preserve_wrapper,
-                rows, columns, overlap, overlap_x, overlap_y, method):
+                rows, columns, overlap, overlap_x, overlap_y, method,
+                color_match="none", color_match_strength=1.0):
         import comfy.utils
         import folder_paths
         from nodes import VAEEncode, VAEDecode, common_ksampler
@@ -221,6 +277,34 @@ class VSLinx_AnimaLLLiteTiledSampler:
 
         vae_encoder = VAEEncode()
         vae_decoder = VAEDecode()
+
+        def color_correct(target, ref):
+            """Match ``target``'s colour to source ``ref`` per the selected mode."""
+            if color_match == "none":
+                return target
+            if color_match == "mean_std":
+                matched = _color_match_meanstd(target, ref)
+            else:
+                matched = _color_match_wavelet(target, ref)
+            matched = matched.clamp(0.0, 1.0)
+            if color_match_strength >= 1.0:
+                return matched
+            return target * (1.0 - color_match_strength) + matched * color_match_strength
+
+        def sample_region(region_img, region_denoise):
+            """LLLite-patched img2img over one region; returns the decoded image."""
+            rh, rw = region_img.shape[1], region_img.shape[2]
+            patched_model = apply_anima_lllite(
+                model, weights_path, region_img, strength,
+                start_percent, end_percent, preserve_wrapper,
+            )
+            latent = vae_encoder.encode(vae, region_img)[0]
+            sampled = common_ksampler(
+                patched_model, seed, steps, cfg, sampler_name, scheduler,
+                positive, negative, latent, denoise=region_denoise,
+            )[0]
+            decoded = vae_decoder.decode(vae, sampled)[0]
+            return _resize_to(decoded, rh, rw, method)
 
         # Process each image of an input batch independently and stitch each one
         # back on its own, so a batch of N images comes out as a batch of N
@@ -238,30 +322,18 @@ class VSLinx_AnimaLLLiteTiledSampler:
             for idx in range(tiles.shape[0]):
                 tile_img = tiles[idx:idx + 1]
                 th, tw = tile_img.shape[1], tile_img.shape[2]
-
-                # Patch the model so the LLLite control image is this tile.
-                patched_model = apply_anima_lllite(
-                    model, weights_path, tile_img, strength,
-                    start_percent, end_percent, preserve_wrapper,
-                )
-
-                latent = vae_encoder.encode(vae, tile_img)[0]
-
-                sampled = common_ksampler(
-                    patched_model, seed, steps, cfg, sampler_name, scheduler,
-                    positive, negative, latent, denoise=denoise,
-                )[0]
-
-                decoded = vae_decoder.decode(vae, sampled)[0]
-
-                # Keep tiles uniform (the VAE may round dims to a multiple of 8) so
-                # the untile geometry and overlaps stay exact.
-                decoded = _resize_to(decoded, th, tw, method)
+                # Keep tiles uniform (the VAE may round dims to a multiple of 8)
+                # so the untile geometry and overlaps stay exact.
+                decoded = _resize_to(sample_region(tile_img, denoise), th, tw, method)
+                # Re-anchor each tile's colour to its source so tiles can't drift
+                # in tone relative to each other (fixes tonal seams).
+                decoded = color_correct(decoded, tile_img)
                 out_tiles.append(decoded)
                 pbar.update(1)
 
-            out_batch = torch.cat(out_tiles, dim=0)
-            results.append(_untile_image(out_batch, ov_w, ov_h, rows, columns))
+            results.append(_untile_image(
+                torch.cat(out_tiles, dim=0), ov_w, ov_h, rows, columns
+            ))
 
         return (torch.cat(results, dim=0),)
 

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -190,6 +190,34 @@ def _color_match_wavelet(target, ref):
     return (t_high + r_low).movedim(1, -1)
 
 
+# --- MultiDiffusion latent tiling (overlap-averaged each denoising step) ------
+
+def _md_spans(total, n, ext):
+    """Cover [0, total] with ``n`` spans; interior edges extended by ``ext`` so
+    neighbours overlap, first span starts at 0 and last reaches ``total``."""
+    base = max(1, total // n)
+    spans = []
+    for i in range(n):
+        s = 0 if i == 0 else i * base - ext
+        e = total if i == n - 1 else (i + 1) * base + ext
+        spans.append((max(0, s), min(total, e)))
+    return spans
+
+
+def _md_weight_1d(length, taper_left, taper_right, device, dtype):
+    """Per-axis blend weight: 1 in the core, linearly ramping across the overlap
+    on each side that abuts a neighbour. Stays > 0 everywhere (safe to divide by
+    the accumulated weight)."""
+    w = torch.ones(length, device=device, dtype=dtype)
+    tl = min(int(taper_left), length // 2)
+    tr = min(int(taper_right), length // 2)
+    if tl > 0:
+        w[:tl] = torch.linspace(0, 1, tl + 2, device=device, dtype=dtype)[1:-1]
+    if tr > 0:
+        w[length - tr:] = torch.linspace(1, 0, tr + 2, device=device, dtype=dtype)[1:-1]
+    return w
+
+
 class VSLinx_AnimaLLLiteTiledSampler:
     @classmethod
     def INPUT_TYPES(cls):
@@ -205,6 +233,9 @@ class VSLinx_AnimaLLLiteTiledSampler:
                 "positive": ("CONDITIONING",),
                 "negative": ("CONDITIONING",),
                 "vae": ("VAE",),
+
+                "sampling_mode": (["per_tile", "multidiffusion"],
+                    {"tooltip": "per_tile: sample each tile fully then stitch (lowest VRAM; can show seams/ghosting). multidiffusion: one sampling pass over the whole image, averaging overlapping tiles in latent space every step — tiles stay in sync so seams and double-exposure are eliminated (slightly more VRAM). In multidiffusion mode the 'method' and 'color_match' fields are not used."}),
 
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
                 "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
@@ -262,7 +293,8 @@ class VSLinx_AnimaLLLiteTiledSampler:
                 seed, steps, cfg, sampler_name, scheduler, denoise,
                 lllite_name, strength, start_percent, end_percent, preserve_wrapper,
                 rows, columns, overlap, overlap_x, overlap_y, method,
-                color_match="none", color_match_strength=1.0):
+                color_match="none", color_match_strength=1.0,
+                sampling_mode="per_tile"):
         import comfy.utils
         import folder_paths
         from nodes import VAEEncode, VAEDecode, common_ksampler
@@ -277,6 +309,21 @@ class VSLinx_AnimaLLLiteTiledSampler:
 
         vae_encoder = VAEEncode()
         vae_decoder = VAEDecode()
+        batch_size = image.shape[0]
+
+        if sampling_mode == "multidiffusion":
+            pbar = comfy.utils.ProgressBar(batch_size)
+            results = []
+            for b in range(batch_size):
+                results.append(self._run_multidiffusion(
+                    image[b:b + 1], model, weights_path, vae, positive, negative,
+                    seed, steps, cfg, sampler_name, scheduler, denoise,
+                    strength, start_percent, end_percent, preserve_wrapper,
+                    rows, columns, overlap, overlap_x, overlap_y,
+                    vae_encoder, vae_decoder,
+                ))
+                pbar.update(1)
+            return (torch.cat(results, dim=0),)
 
         def color_correct(target, ref):
             """Match ``target``'s colour to source ``ref`` per the selected mode."""
@@ -309,7 +356,6 @@ class VSLinx_AnimaLLLiteTiledSampler:
         # Process each image of an input batch independently and stitch each one
         # back on its own, so a batch of N images comes out as a batch of N
         # results (without this the tiles of different images would be mixed).
-        batch_size = image.shape[0]
         pbar = comfy.utils.ProgressBar(batch_size * rows * columns)
 
         results = []
@@ -336,6 +382,122 @@ class VSLinx_AnimaLLLiteTiledSampler:
             ))
 
         return (torch.cat(results, dim=0),)
+
+    def _run_multidiffusion(self, img, model, weights_path, vae, positive, negative,
+                            seed, steps, cfg, sampler_name, scheduler, denoise,
+                            strength, start_percent, end_percent, preserve_wrapper,
+                            rows, columns, overlap, overlap_x, overlap_y,
+                            vae_encoder, vae_decoder):
+        """MultiDiffusion: one sampler pass over the whole latent, tiling + LLLite
+        applied per-tile and averaged in latent space at every denoising step.
+
+        Tiles never run to completion independently, so they stay consistent and
+        there are no seams or double-exposures to blend away.
+        """
+        from nodes import common_ksampler
+        from ._vendor.anima_lllite_apply import build_anima_lllite, prepare_cond_image
+
+        lllite, patch_spatial, cond_in_channels, _ = build_anima_lllite(
+            model, weights_path, strength
+        )
+        if cond_in_channels == 4:
+            raise ValueError(
+                "MultiDiffusion mode does not support 4-channel (inpaint) LLLite weights."
+            )
+
+        model_sampling = model.get_model_object("model_sampling")
+        sigma_start = float(model_sampling.percent_to_sigma(start_percent))
+        sigma_end = float(model_sampling.percent_to_sigma(end_percent))
+
+        src_image = img.detach().clone()
+
+        # Encode the whole image once (ComfyUI auto-tiles the VAE if it would OOM).
+        latent = vae_encoder.encode(vae, img)[0]
+        x0 = latent["samples"]
+        latent_h, latent_w = int(x0.shape[-2]), int(x0.shape[-1])
+
+        # Latent-space tile grid (covers the full latent; last tile reaches the edge).
+        tile_hl = max(1, latent_h // rows)
+        tile_wl = max(1, latent_w // columns)
+        ov_hl = 0 if rows == 1 else min(int(tile_hl * overlap) + overlap_y // 8, tile_hl // 2)
+        ov_wl = 0 if columns == 1 else min(int(tile_wl * overlap) + overlap_x // 8, tile_wl // 2)
+        ys = _md_spans(latent_h, rows, ov_hl)
+        xs = _md_spans(latent_w, columns, ov_wl)
+
+        state = {"tag": None, "tiles": None}
+
+        def build_tiles(device, dtype):
+            tiles = []
+            for i, (y0, y1) in enumerate(ys):
+                ty_l = (ys[i - 1][1] - y0) if i > 0 else 0
+                ty_r = (y1 - ys[i + 1][0]) if i < rows - 1 else 0
+                wy = _md_weight_1d(y1 - y0, ty_l, ty_r, device, dtype)
+                for j, (x0, x1) in enumerate(xs):
+                    tx_l = (xs[j - 1][1] - x0) if j > 0 else 0
+                    tx_r = (x1 - xs[j + 1][0]) if j < columns - 1 else 0
+                    wx = _md_weight_1d(x1 - x0, tx_l, tx_r, device, dtype)
+                    weight = wy[:, None] * wx[None, :]  # (th, tw)
+                    # control-image crop for this tile (latent box -> pixel box).
+                    cond_crop = src_image[:, y0 * 8:y1 * 8, x0 * 8:x1 * 8, :]
+                    cond_pp = prepare_cond_image(
+                        cond_crop, y1 - y0, x1 - x0, device, dtype, patch_spatial
+                    )
+                    tiles.append({"y0": y0, "y1": y1, "x0": x0, "x1": x1,
+                                  "weight": weight, "cond": cond_pp})
+            return tiles
+
+        old_wrapper = model.model_options.get("model_function_wrapper")
+
+        def call_model(apply_model, xt, t, c):
+            if preserve_wrapper and old_wrapper is not None:
+                return old_wrapper(apply_model, {"input": xt, "timestep": t, "c": c})
+            return apply_model(xt, t, **c)
+
+        def wrapper(apply_model, args):
+            x_in = args["input"]
+            t = args["timestep"]
+            c = args["c"]
+            device, dtype = x_in.device, x_in.dtype
+
+            tag = (device, dtype)
+            if state["tag"] != tag:
+                lllite.to(device=device, dtype=dtype)
+                state["tiles"] = build_tiles(device, dtype)
+                state["tag"] = tag
+
+            active = sigma_end <= float(t.max().item()) <= sigma_start
+
+            acc = torch.zeros_like(x_in)
+            lead = (1,) * (x_in.ndim - 2)
+            wsum = torch.zeros(lead + (x_in.shape[-2], x_in.shape[-1]),
+                               device=device, dtype=dtype)
+
+            for td in state["tiles"]:
+                y0, y1, x0, x1 = td["y0"], td["y1"], td["x0"], td["x1"]
+                x_tile = x_in[..., y0:y1, x0:x1]
+                if active:
+                    lllite.set_multiplier(strength)
+                    lllite.set_cond_image(td["cond"])
+                    lllite.apply_to()
+                try:
+                    eps = call_model(apply_model, x_tile, t, c)
+                finally:
+                    if active:
+                        lllite.restore()
+                        lllite.clear_cond_image()
+                wb = td["weight"].view(lead + td["weight"].shape)
+                acc[..., y0:y1, x0:x1] += eps * wb
+                wsum[..., y0:y1, x0:x1] += wb
+
+            return acc / wsum.clamp(min=1e-6)
+
+        m = model.clone()
+        m.set_model_unet_function_wrapper(wrapper)
+        sampled = common_ksampler(
+            m, seed, steps, cfg, sampler_name, scheduler,
+            positive, negative, latent, denoise=denoise,
+        )[0]
+        return vae_decoder.decode(vae, sampled)[0]
 
 
 NODE_CLASS_MAPPINGS = {

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -222,41 +222,48 @@ class VSLinx_AnimaLLLiteTiledSampler:
         vae_encoder = VAEEncode()
         vae_decoder = VAEDecode()
 
-        tiles, tile_w_full, tile_h_full, ov_w, ov_h = _tile_image(
-            image, rows, columns, overlap, overlap_x, overlap_y
-        )
-        num_tiles = tiles.shape[0]
+        # Process each image of an input batch independently and stitch each one
+        # back on its own, so a batch of N images comes out as a batch of N
+        # results (without this the tiles of different images would be mixed).
+        batch_size = image.shape[0]
+        pbar = comfy.utils.ProgressBar(batch_size * rows * columns)
 
-        pbar = comfy.utils.ProgressBar(num_tiles)
-        out_tiles = []
-        for idx in range(num_tiles):
-            tile_img = tiles[idx:idx + 1]
-            th, tw = tile_img.shape[1], tile_img.shape[2]
-
-            # Patch the model so the LLLite control image is this tile.
-            patched_model = apply_anima_lllite(
-                model, weights_path, tile_img, strength,
-                start_percent, end_percent, preserve_wrapper,
+        results = []
+        for b in range(batch_size):
+            tiles, tile_w_full, tile_h_full, ov_w, ov_h = _tile_image(
+                image[b:b + 1], rows, columns, overlap, overlap_x, overlap_y
             )
 
-            latent = vae_encoder.encode(vae, tile_img)[0]
+            out_tiles = []
+            for idx in range(tiles.shape[0]):
+                tile_img = tiles[idx:idx + 1]
+                th, tw = tile_img.shape[1], tile_img.shape[2]
 
-            sampled = common_ksampler(
-                patched_model, seed, steps, cfg, sampler_name, scheduler,
-                positive, negative, latent, denoise=denoise,
-            )[0]
+                # Patch the model so the LLLite control image is this tile.
+                patched_model = apply_anima_lllite(
+                    model, weights_path, tile_img, strength,
+                    start_percent, end_percent, preserve_wrapper,
+                )
 
-            decoded = vae_decoder.decode(vae, sampled)[0]
+                latent = vae_encoder.encode(vae, tile_img)[0]
 
-            # Keep tiles uniform (the VAE may round dims to a multiple of 8) so the
-            # untile geometry and overlaps stay exact.
-            decoded = _resize_to(decoded, th, tw, method)
-            out_tiles.append(decoded)
-            pbar.update(1)
+                sampled = common_ksampler(
+                    patched_model, seed, steps, cfg, sampler_name, scheduler,
+                    positive, negative, latent, denoise=denoise,
+                )[0]
 
-        out_batch = torch.cat(out_tiles, dim=0)
-        result = _untile_image(out_batch, ov_w, ov_h, rows, columns)
-        return (result,)
+                decoded = vae_decoder.decode(vae, sampled)[0]
+
+                # Keep tiles uniform (the VAE may round dims to a multiple of 8) so
+                # the untile geometry and overlaps stay exact.
+                decoded = _resize_to(decoded, th, tw, method)
+                out_tiles.append(decoded)
+                pbar.update(1)
+
+            out_batch = torch.cat(out_tiles, dim=0)
+            results.append(_untile_image(out_batch, ov_w, ov_h, rows, columns))
+
+        return (torch.cat(results, dim=0),)
 
 
 NODE_CLASS_MAPPINGS = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: multi-select image loaders (batch/list) and an auto-refreshing last-image loader; image-into-mask-bbox compositing; pixel-art with retro palettes (GameBoy, CGA, NES, Pico-8); exact-factor model upscaling (nearest/bilinear/area/Lanczos); batched VAE Decode/Tiled to cut peak VRAM; an interactive Impact-Pack detailer with per-segment prompts; boolean AND/OR/flip plus bypass/mute nodes driven by a boolean or another node's state; Any to Pipe / Pipe to Any to bundle up to 5 values into one wire; group bookmarks; multiline wildcard text for Impact-Pack; and an rgthree Power LoRA Loader to Image Saver metadata bridge. Also adds settings for model/LoRA hover previews in all loaders (rgthree subdirectory compatible) and a fix for 'Return type mismatch' errors from scheduler-extending nodes like RES4LYF."
-version = "1.11.0"
+version = "1.11.1"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: multi-select image loaders (batch/list) and an auto-refreshing last-image loader; image-into-mask-bbox compositing; pixel-art with retro palettes (GameBoy, CGA, NES, Pico-8); exact-factor model upscaling (nearest/bilinear/area/Lanczos); batched VAE Decode/Tiled to cut peak VRAM; an interactive Impact-Pack detailer with per-segment prompts; boolean AND/OR/flip plus bypass/mute nodes driven by a boolean or another node's state; Any to Pipe / Pipe to Any to bundle up to 5 values into one wire; group bookmarks; multiline wildcard text for Impact-Pack; and an rgthree Power LoRA Loader to Image Saver metadata bridge. Also adds settings for model/LoRA hover previews in all loaders (rgthree subdirectory compatible) and a fix for 'Return type mismatch' errors from scheduler-extending nodes like RES4LYF."
-version = "1.11.1"
+version = "1.12.0"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
+++ b/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
@@ -35,6 +35,8 @@ Parameters:
 | overlap_x | INT | Extra horizontal overlap in pixels. |
 | overlap_y | INT | Extra vertical overlap in pixels. |
 | method | COMBO | Resampling (``lanczos``, ``nearest-exact``, ``bilinear``, ``area``, ``bicubic``) used to keep every decoded tile at a uniform size before stitching. |
+| color_match | COMBO | Per-tile color matching against the source tile, to fix tonal seams (brightness/colour steps between tiles). ``none`` (default), ``mean_std`` (re-scales each tile's per-channel mean/std — fast, simple), ``wavelet`` (keeps the tile's detail but takes the source tile's broad tone — better on textured tiles). |
+| color_match_strength | FLOAT | How strongly to apply the color match (``0`` = off, ``1`` = full). |
 
 Outputs:
 | Parameter | Type | Description |
@@ -45,4 +47,5 @@ Notes:
 - Like the essentials Image Tile node, the image is cropped to a whole number of tiles (``columns × tile_width`` by ``rows × tile_height``), so the output can be a few pixels smaller than the input.
 - The overlaps used for stitching are the ones actually computed during tiling (after clamping to at most half a tile), so the geometry always lines up even if ``overlap_x``/``overlap_y`` exceed half the tile size.
 - For lower VRAM use more ``rows``/``columns`` (smaller tiles) rather than a tiled VAE — splitting the VAE pass tends to hurt quality without a meaningful speed gain at these tile sizes.
+- Tiles sampled independently can drift in overall tone, leaving a faint brightness/colour step (seam) across smooth areas — most visible on gradients like skin or sky. ``color_match`` re-anchors each tile's colour to its source tile so the tones stay consistent and the step disappears.
 - 4-channel (inpaint) LLLite weights are not supported here since they require a per-tile mask; use the standalone AnimaLLLiteApply node for that case.

--- a/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
+++ b/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
@@ -8,6 +8,12 @@ For every tile in the ``rows`` × ``columns`` grid the node:
 
 When all tiles are done they are feathered along their overlaps and <b>stitched back</b> into a single image (same algorithm as comfyui_essentials Image Tile / Image Untile). All tiles share the same ``seed``.
 
+<b>Two sampling modes</b> (``sampling_mode``):
+<ul>
+<li><b>per_tile</b> (default) — the process above: each tile is sampled to completion, then the tiles are stitched. Lowest VRAM. Because tiles are sampled independently they can show seams or "double-exposure" ghosting where neighbours disagree; ``color_match`` and overlap help but can't fully remove it.</li>
+<li><b>multidiffusion</b> — a single sampling pass over the <b>whole</b> latent. Every denoising step the latent is split into overlapping tiles, the model is run per tile (each with its own LLLite control crop), and the predictions are <b>averaged in latent space</b>. Because the tiles are re-synced every step they cannot diverge, so seams and double-exposure are eliminated. Uses a little more VRAM (it holds the full latent), and ``method`` / ``color_match`` do not apply.</li>
+</ul>
+
 <b>No extra node packs are required.</b> The Anima ControlNet-LLLite apply logic is bundled (vendored from <a href="https://github.com/kohya-ss/ComfyUI-Anima-LLLite">kohya-ss/ComfyUI-Anima-LLLite</a>, Apache 2.0), so the node works on its own.
 
 Parameters:
@@ -18,6 +24,7 @@ Parameters:
 | positive | CONDITIONING | Positive conditioning, shared across all tiles. |
 | negative | CONDITIONING | Negative conditioning, shared across all tiles. |
 | vae | VAE | VAE used to encode/decode each tile. |
+| sampling_mode | COMBO | ``per_tile`` (sample tiles then stitch — lowest VRAM, can seam) or ``multidiffusion`` (one pass, overlap-averaged each step — no seams, slightly more VRAM). |
 | seed | INT | Sampling seed (same for every tile). |
 | steps | INT | KSampler steps. |
 | cfg | FLOAT | Classifier-free guidance scale. |
@@ -34,9 +41,9 @@ Parameters:
 | overlap | FLOAT | Overlap between tiles as a fraction of tile size (added on top of overlap_x/overlap_y). |
 | overlap_x | INT | Extra horizontal overlap in pixels. |
 | overlap_y | INT | Extra vertical overlap in pixels. |
-| method | COMBO | Resampling (``lanczos``, ``nearest-exact``, ``bilinear``, ``area``, ``bicubic``) used to keep every decoded tile at a uniform size before stitching. |
-| color_match | COMBO | Per-tile color matching against the source tile, to fix tonal seams (brightness/colour steps between tiles). ``none`` (default), ``mean_std`` (re-scales each tile's per-channel mean/std — fast, simple), ``wavelet`` (keeps the tile's detail but takes the source tile's broad tone — better on textured tiles). |
-| color_match_strength | FLOAT | How strongly to apply the color match (``0`` = off, ``1`` = full). |
+| method | COMBO | (per_tile only) Resampling (``lanczos``, ``nearest-exact``, ``bilinear``, ``area``, ``bicubic``) used to keep every decoded tile at a uniform size before stitching. |
+| color_match | COMBO | (per_tile only) Per-tile color matching against the source tile, to fix tonal seams (brightness/colour steps between tiles). ``none`` (default), ``mean_std`` (re-scales each tile's per-channel mean/std — fast, simple), ``wavelet`` (keeps the tile's detail but takes the source tile's broad tone — better on textured tiles). |
+| color_match_strength | FLOAT | (per_tile only) How strongly to apply the color match (``0`` = off, ``1`` = full). |
 
 Outputs:
 | Parameter | Type | Description |
@@ -47,5 +54,6 @@ Notes:
 - Like the essentials Image Tile node, the image is cropped to a whole number of tiles (``columns × tile_width`` by ``rows × tile_height``), so the output can be a few pixels smaller than the input.
 - The overlaps used for stitching are the ones actually computed during tiling (after clamping to at most half a tile), so the geometry always lines up even if ``overlap_x``/``overlap_y`` exceed half the tile size.
 - For lower VRAM use more ``rows``/``columns`` (smaller tiles) rather than a tiled VAE — splitting the VAE pass tends to hurt quality without a meaningful speed gain at these tile sizes.
-- Tiles sampled independently can drift in overall tone, leaving a faint brightness/colour step (seam) across smooth areas — most visible on gradients like skin or sky. ``color_match`` re-anchors each tile's colour to its source tile so the tones stay consistent and the step disappears.
+- In ``per_tile`` mode, tiles sampled independently can drift in overall tone, leaving a faint brightness/colour step (seam) across smooth areas, and can disagree structurally (a "double-exposure" in the overlap). ``color_match`` fixes the tonal step; for structural seams use ``multidiffusion``.
+- ``multidiffusion`` mode removes seams at the source: tiles are re-synced (overlap-averaged in latent space) at every denoising step, so they can't diverge. It does one full-image VAE encode/decode (ComfyUI auto-tiles the VAE if it would otherwise run out of memory) and holds the full latent in memory, so it uses a little more VRAM than ``per_tile``. ``method`` and ``color_match`` are not used in this mode.
 - 4-channel (inpaint) LLLite weights are not supported here since they require a per-tile mask; use the standalone AnimaLLLiteApply node for that case.


### PR DESCRIPTION
# Anima LLLite Tiled Sampler: MultiDiffusion sampling mode

## Summary
Adds a `sampling_mode` selector to the **Anima LLLite Tiled ControlNet Sampler**, with a new **`multidiffusion`** mode that eliminates tile seams and "double-exposure" ghosting at the source.

## The problem
In the existing `per_tile` mode, each tile is sampled to completion independently and then the tiles are stitched. Because neighbouring tiles diffuse independently, they can disagree:
- **structural divergence** → "double-exposure" ghosting in the overlap, and
- a **tonal/edge seam** along the boundary.

Blending mitigations (overlap feathering, `color_match`) reduce these but can't fully remove structural disagreement — you can't average two different drawings into one correct drawing.

## The fix: `multidiffusion`
A single sampling pass over the **whole** latent. Every denoising step the wrapper:
1. splits the latent into overlapping tiles,
2. runs the model per tile (each with its own LLLite control-image crop),
3. **averages the overlapping predictions in latent space** (smooth taper weights).

Because the tiles are re-synced every step they can't diverge, so seams and ghosting are gone. One full-image VAE encode/decode replaces the per-tile round-trips (ComfyUI auto-tiles the VAE if it would OOM).

- `sampling_mode`: `per_tile` (default, unchanged) / `multidiffusion`
- In `multidiffusion`, `method` and `color_match` don't apply (no stitching step).

## Notes / trade-offs
- Same number of model evaluations as `per_tile` (`tiles × steps`), but it builds LLLite once and does a single VAE encode/decode instead of per-tile — so in practice it can be **faster**.
- Uses a little more VRAM (holds the full latent + an accumulation buffer); `per_tile` remains the lower-VRAM fallback for very large outputs.
- Overlap regions are averaged, so they can be marginally softer than a fully independent tile; bigger overlap = smoother but softer.
