### PR TITLE
feat(sampling): add MultiDiffusion Tiled Hires Fix node + tiled VAE decode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ It exposes the sampler fields (``seed``, ``steps``, ``cfg``, ``sampler``, ``sche
 
 It has two ``sampling_mode``s:
 - **``per_tile``** (default) — sample each tile to completion, then stitch. Lowest VRAM. Because tiles are sampled independently they can show seams or "double-exposure" ghosting; the optional ``color_match`` (``mean_std`` / ``wavelet``, with ``color_match_strength``) re-anchors each tile's colour to its source tile to fix *tonal* seams (brightness/colour steps), but it can't fully remove structural disagreement.
-- **``multidiffusion``** — a single sampling pass over the whole image that splits the latent into overlapping tiles every denoising step, runs the model per tile (each with its own LLLite control crop), and averages the overlaps in latent space. The tiles are re-synced every step so they can't diverge — seams and double-exposure are eliminated. Uses a little more VRAM (it holds the full latent), and ``method`` / ``color_match`` don't apply.
+- **``multidiffusion``** — a single sampling pass over the whole image that splits the latent into overlapping tiles every denoising step, runs the model per tile (each with its own LLLite control crop), and averages the overlaps in latent space. The tiles are re-synced every step so they can't diverge — seams and double-exposure are eliminated. Uses a little more VRAM (it holds the full latent), and ``method`` / ``color_match`` don't apply. Its final VAE decode is a single full-image pass (independent of ``rows``/``columns``); if that pins your VRAM, enable ``vae_decode_tiled`` (with ``vae_decode_tile_size``) to decode it in tiles. These two fields only show in ``multidiffusion`` mode.
 
 The ``LLLite Model`` can be picked on the node's own dropdown, or driven from outside by connecting the **Load Anima LLLite Model** node (below) — handy for selecting it once and driving several samplers, or keeping model selection in a loaders group.
 
@@ -187,6 +187,9 @@ The ``LLLite Model`` can be picked on the node's own dropdown, or driven from ou
 
 #### Load Anima LLLite Model
 A small loader that selects an Anima ControlNet-LLLite weights file (from the ``controlnet`` folder) and outputs its filename for the **Anima LLLite Tiled ControlNet Sampler**'s ``lllite_name`` input — letting you choose the LLLite model once and route it into one or more samplers. It only outputs the filename (the LLLite module is built inside the sampler), so it needs no other node packs.
+
+#### MultiDiffusion Tiled Hires Fix
+A model-agnostic **tiled hires-fix / refiner** — the ``multidiffusion`` behaviour of the Anima sampler with the LLLite parts removed, so it works on any model (SD/SDXL/Flux/etc.) and needs no extra node packs. It runs a single sampling pass over the whole image, splitting the latent into overlapping tiles every denoising step and averaging the overlaps in latent space, so there are no tile seams and per-step UNet activations stay tile-sized (whole-image coherence at roughly tile-sized peak VRAM). It doesn't upscale on its own: upscale the image first, then refine it here with a low ``denoise`` (~0.3–0.5). The same optional ``vae_decode_tiled`` / ``vae_decode_tile_size`` keep the final full-image decode from spiking VRAM. Findable in node search under ``hires fix``, ``tiled diffusion``, ``multidiffusion``, ``tiled upscale`` and similar.
 
 ### Inpaint helper
 #### Fit Image into BBox Mask
@@ -204,6 +207,10 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.14.0
+- added an optional ``vae_decode_tiled`` (with ``vae_decode_tile_size``) to the ``Anima LLLite Tiled ControlNet Sampler`` for ``multidiffusion`` mode. That mode's final VAE decode is a single full-image pass (independent of ``rows``/``columns``), which can spike VRAM on large images — or, on Windows, crawl by spilling into shared system memory instead of raising a clean out-of-memory error. Enabling it decodes the latent in bounded tiles. Default off, and the two fields only show when ``sampling_mode`` is ``multidiffusion`` (they have no effect in ``per_tile`` mode, where each tile is already decoded on its own).
+- added a new model-agnostic ``MultiDiffusion Tiled Hires Fix`` node in the ``vsLinx/sampling`` group. It's the ``multidiffusion`` behaviour of the ``Anima LLLite Tiled ControlNet Sampler`` with the LLLite parts stripped out, so it works on any model (SD/SDXL/Flux/etc.): one sampling pass over the whole image, splitting the latent into overlapping tiles each denoising step and averaging the overlaps in latent space — no tile seams, and per-step VRAM stays tile-sized. Upscale the image first, then refine it here with a low ``denoise``. Includes the optional ``vae_decode_tiled``/``vae_decode_tile_size`` and search aliases like ``hires fix`` / ``tiled diffusion`` / ``tiled upscale`` so it's findable without knowing the term "multidiffusion".
+
 ### v.1.13.0
 - added a new ``Load Anima LLLite Model``-Node in the ``vsLinx/sampling`` group that outputs an LLLite weights filename for the ``Anima LLLite Tiled ControlNet Sampler``'s ``lllite_name`` input - letting you select the LLLite model from outside the sampler (e.g. choose it once for several samplers, or keep it in a loaders group).
 

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,7 @@ node_list = [
     "pipe_utils",
     "vae_decode_batched",
     "anima_lllite_tiled_sampler",
+    "multidiffusion_tiled_hires",
 ]
 
 NODE_CLASS_MAPPINGS = {}

--- a/nodes/anima_lllite_tiled_sampler.py
+++ b/nodes/anima_lllite_tiled_sampler.py
@@ -267,6 +267,11 @@ class VSLinx_AnimaLLLiteTiledSampler:
                     {"tooltip": "Per-tile color matching against the source tile, to fix tonal seams (brightness/colour steps between tiles). 'mean_std' re-scales each tile's per-channel mean/std (fast, simple); 'wavelet' keeps the tile's detail but takes the source tile's broad tone (better on textured tiles)."}),
                 "color_match_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01,
                     "tooltip": "How strongly to apply the color match (0 = off, 1 = full)."}),
+
+                "vae_decode_tiled": ("BOOLEAN", {"default": False,
+                    "tooltip": "(multidiffusion only) Decode the final full-image latent in tiles instead of one pass, to avoid a single huge VAE decode that can spike VRAM (or spill into slow shared system memory). No effect in per_tile mode, where each tile is already decoded on its own."}),
+                "vae_decode_tile_size": ("INT", {"default": 512, "min": 64, "max": 4096, "step": 32,
+                    "tooltip": "(multidiffusion only) Tile size in pixels for the tiled VAE decode."}),
             },
         }
 
@@ -294,7 +299,8 @@ class VSLinx_AnimaLLLiteTiledSampler:
                 lllite_name, strength, start_percent, end_percent, preserve_wrapper,
                 rows, columns, overlap, overlap_x, overlap_y, method,
                 color_match="none", color_match_strength=1.0,
-                sampling_mode="per_tile"):
+                sampling_mode="per_tile",
+                vae_decode_tiled=False, vae_decode_tile_size=512):
         import comfy.utils
         import folder_paths
         from nodes import VAEEncode, VAEDecode, common_ksampler
@@ -321,6 +327,7 @@ class VSLinx_AnimaLLLiteTiledSampler:
                     strength, start_percent, end_percent, preserve_wrapper,
                     rows, columns, overlap, overlap_x, overlap_y,
                     vae_encoder, vae_decoder,
+                    vae_decode_tiled, vae_decode_tile_size,
                 ))
                 pbar.update(1)
             return (torch.cat(results, dim=0),)
@@ -387,7 +394,8 @@ class VSLinx_AnimaLLLiteTiledSampler:
                             seed, steps, cfg, sampler_name, scheduler, denoise,
                             strength, start_percent, end_percent, preserve_wrapper,
                             rows, columns, overlap, overlap_x, overlap_y,
-                            vae_encoder, vae_decoder):
+                            vae_encoder, vae_decoder,
+                            vae_decode_tiled=False, vae_decode_tile_size=512):
         """MultiDiffusion: one sampler pass over the whole latent, tiling + LLLite
         applied per-tile and averaged in latent space at every denoising step.
 
@@ -497,6 +505,11 @@ class VSLinx_AnimaLLLiteTiledSampler:
             m, seed, steps, cfg, sampler_name, scheduler,
             positive, negative, latent, denoise=denoise,
         )[0]
+        if vae_decode_tiled:
+            # Decode the full-image latent in tiles, so the final decode can't
+            # spike VRAM (or, on Windows, spill into slow shared system memory).
+            from nodes import VAEDecodeTiled
+            return VAEDecodeTiled().decode(vae, sampled, tile_size=vae_decode_tile_size)[0]
         return vae_decoder.decode(vae, sampled)[0]
 
 

--- a/nodes/multidiffusion_tiled_hires.py
+++ b/nodes/multidiffusion_tiled_hires.py
@@ -1,0 +1,211 @@
+"""
+vsLinx MultiDiffusion Tiled Hires Fix
+
+A model-agnostic tiled hires-fix / refine sampler. It is the ``multidiffusion``
+behaviour of the Anima LLLite Tiled ControlNet Sampler with the LLLite parts
+removed, so it works on any model (SD/SDXL/Flux/etc.).
+
+It runs a single sampling pass over the whole latent: every denoising step the
+latent is split into overlapping tiles, the model is evaluated per tile, and the
+predictions are averaged in latent space (MultiDiffusion, Bar-Tal et al.).
+Because the tiles are re-synced every step they can't diverge, so there are no
+seams or "double-exposure" ghosting to blend away, and per-step UNet activations
+stay tile-sized (whole-image coherence at roughly tile-sized peak VRAM).
+
+This node does not upscale on its own — upscale the image first (e.g. "Upscale
+Image By"), then feed it in with a low ``denoise`` (~0.3–0.5) to refine it.
+
+The MultiDiffusion tiling math (``_md_spans`` / ``_md_weight_1d``) is shared with
+the Anima sampler so there is a single source of truth for it.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from .anima_lllite_tiled_sampler import _md_spans, _md_weight_1d
+
+
+class VSLinx_MultiDiffusionTiledHiresFix:
+    @classmethod
+    def INPUT_TYPES(cls):
+        import comfy.samplers
+        from nodes import MAX_RESOLUTION
+
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "model": ("MODEL",),
+                "positive": ("CONDITIONING",),
+                "negative": ("CONDITIONING",),
+                "vae": ("VAE",),
+
+                "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff, "control_after_generate": True}),
+                "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
+                "cfg": ("FLOAT", {"default": 7.0, "min": 0.0, "max": 100.0, "step": 0.1, "round": 0.01}),
+                "sampler_name": (comfy.samplers.KSampler.SAMPLERS,),
+                "scheduler": (comfy.samplers.KSampler.SCHEDULERS,),
+                "denoise": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01,
+                    "tooltip": "Denoise strength. For a tiled hires-fix on an already-upscaled image keep this low (e.g. 0.3-0.5)."}),
+
+                "rows": ("INT", {"default": 2, "min": 1, "max": 256, "step": 1}),
+                "columns": ("INT", {"default": 2, "min": 1, "max": 256, "step": 1}),
+                "overlap": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 0.5, "step": 0.01,
+                    "tooltip": "Overlap between tiles as a fraction of tile size, added on top of overlap_x/overlap_y."}),
+                "overlap_x": ("INT", {"default": 64, "min": 0, "max": MAX_RESOLUTION // 2, "step": 1,
+                    "tooltip": "Extra horizontal overlap in pixels."}),
+                "overlap_y": ("INT", {"default": 64, "min": 0, "max": MAX_RESOLUTION // 2, "step": 1,
+                    "tooltip": "Extra vertical overlap in pixels."}),
+
+                "vae_decode_tiled": ("BOOLEAN", {"default": False,
+                    "tooltip": "Decode the final full-image latent in tiles instead of one pass, to avoid a single huge VAE decode that can spike VRAM (or, on Windows, spill into slow shared system memory). The decode is a single full-image pass independent of rows/columns, so adding tiles won't shrink it - enable this instead."}),
+                "vae_decode_tile_size": ("INT", {"default": 512, "min": 64, "max": 4096, "step": 32,
+                    "tooltip": "Tile size in pixels for the tiled VAE decode."}),
+            },
+        }
+
+    RETURN_TYPES = ("IMAGE",)
+    RETURN_NAMES = ("image",)
+    FUNCTION = "execute"
+    CATEGORY = "vsLinx/sampling"
+    DESCRIPTION = (
+        "Model-agnostic MultiDiffusion tiled hires-fix / refiner. Runs one "
+        "sampling pass over the whole image, splitting the latent into "
+        "overlapping tiles every denoising step and averaging the overlaps in "
+        "latent space, so there are no tile seams and per-step VRAM stays "
+        "tile-sized. Upscale the image first, then refine it here with a low "
+        "denoise. Works on any model (SD/SDXL/Flux/etc.) - no extra node packs."
+    )
+    SEARCH_ALIASES = [
+        "hires fix",
+        "hi-res fix",
+        "tiled hires fix",
+        "multidiffusion",
+        "multi diffusion",
+        "tiled diffusion",
+        "tiled upscale",
+        "tiled sampler",
+        "tiled ksampler",
+        "seamless tiled sampling",
+        "mixture of diffusers",
+    ]
+
+    def execute(self, image, model, positive, negative, vae,
+                seed, steps, cfg, sampler_name, scheduler, denoise,
+                rows, columns, overlap, overlap_x, overlap_y,
+                vae_decode_tiled=False, vae_decode_tile_size=512):
+        import comfy.utils
+        from nodes import VAEEncode, VAEDecode
+
+        vae_encoder = VAEEncode()
+        vae_decoder = VAEDecode()
+        batch_size = image.shape[0]
+
+        pbar = comfy.utils.ProgressBar(batch_size)
+        results = []
+        for b in range(batch_size):
+            results.append(self._run(
+                image[b:b + 1], model, vae, positive, negative,
+                seed, steps, cfg, sampler_name, scheduler, denoise,
+                rows, columns, overlap, overlap_x, overlap_y,
+                vae_encoder, vae_decoder,
+                vae_decode_tiled, vae_decode_tile_size,
+            ))
+            pbar.update(1)
+        return (torch.cat(results, dim=0),)
+
+    def _run(self, img, model, vae, positive, negative,
+             seed, steps, cfg, sampler_name, scheduler, denoise,
+             rows, columns, overlap, overlap_x, overlap_y,
+             vae_encoder, vae_decoder,
+             vae_decode_tiled=False, vae_decode_tile_size=512):
+        """One MultiDiffusion pass over the whole latent: tile + overlap-average
+        the model's prediction at every denoising step."""
+        from nodes import common_ksampler
+
+        # Encode the whole image once (ComfyUI auto-tiles the VAE if it would OOM).
+        latent = vae_encoder.encode(vae, img)[0]
+        x0 = latent["samples"]
+        latent_h, latent_w = int(x0.shape[-2]), int(x0.shape[-1])
+
+        # Latent-space tile grid (covers the full latent; last tile reaches the edge).
+        tile_hl = max(1, latent_h // rows)
+        tile_wl = max(1, latent_w // columns)
+        ov_hl = 0 if rows == 1 else min(int(tile_hl * overlap) + overlap_y // 8, tile_hl // 2)
+        ov_wl = 0 if columns == 1 else min(int(tile_wl * overlap) + overlap_x // 8, tile_wl // 2)
+        ys = _md_spans(latent_h, rows, ov_hl)
+        xs = _md_spans(latent_w, columns, ov_wl)
+
+        state = {"tag": None, "tiles": None}
+
+        def build_tiles(device, dtype):
+            tiles = []
+            for i, (y0, y1) in enumerate(ys):
+                ty_l = (ys[i - 1][1] - y0) if i > 0 else 0
+                ty_r = (y1 - ys[i + 1][0]) if i < rows - 1 else 0
+                wy = _md_weight_1d(y1 - y0, ty_l, ty_r, device, dtype)
+                for j, (x0, x1) in enumerate(xs):
+                    tx_l = (xs[j - 1][1] - x0) if j > 0 else 0
+                    tx_r = (x1 - xs[j + 1][0]) if j < columns - 1 else 0
+                    wx = _md_weight_1d(x1 - x0, tx_l, tx_r, device, dtype)
+                    weight = wy[:, None] * wx[None, :]  # (th, tw)
+                    tiles.append({"y0": y0, "y1": y1, "x0": x0, "x1": x1, "weight": weight})
+            return tiles
+
+        # Delegate to any wrapper already installed upstream so this node can
+        # stack with other model_function_wrapper nodes instead of clobbering them.
+        old_wrapper = model.model_options.get("model_function_wrapper")
+
+        def call_model(apply_model, xt, t, c):
+            if old_wrapper is not None:
+                return old_wrapper(apply_model, {"input": xt, "timestep": t, "c": c})
+            return apply_model(xt, t, **c)
+
+        def wrapper(apply_model, args):
+            x_in = args["input"]
+            t = args["timestep"]
+            c = args["c"]
+            device, dtype = x_in.device, x_in.dtype
+
+            tag = (device, dtype)
+            if state["tag"] != tag:
+                state["tiles"] = build_tiles(device, dtype)
+                state["tag"] = tag
+
+            acc = torch.zeros_like(x_in)
+            lead = (1,) * (x_in.ndim - 2)
+            wsum = torch.zeros(lead + (x_in.shape[-2], x_in.shape[-1]),
+                               device=device, dtype=dtype)
+
+            for td in state["tiles"]:
+                y0, y1, x0, x1 = td["y0"], td["y1"], td["x0"], td["x1"]
+                x_tile = x_in[..., y0:y1, x0:x1]
+                eps = call_model(apply_model, x_tile, t, c)
+                wb = td["weight"].view(lead + td["weight"].shape)
+                acc[..., y0:y1, x0:x1] += eps * wb
+                wsum[..., y0:y1, x0:x1] += wb
+
+            return acc / wsum.clamp(min=1e-6)
+
+        m = model.clone()
+        m.set_model_unet_function_wrapper(wrapper)
+        sampled = common_ksampler(
+            m, seed, steps, cfg, sampler_name, scheduler,
+            positive, negative, latent, denoise=denoise,
+        )[0]
+
+        if vae_decode_tiled:
+            # Decode the full-image latent in tiles, so the final decode can't
+            # spike VRAM (or, on Windows, spill into slow shared system memory).
+            from nodes import VAEDecodeTiled
+            return VAEDecodeTiled().decode(vae, sampled, tile_size=vae_decode_tile_size)[0]
+        return vae_decoder.decode(vae, sampled)[0]
+
+
+NODE_CLASS_MAPPINGS = {
+    "vsLinx_MultiDiffusionTiledHiresFix": VSLinx_MultiDiffusionTiledHiresFix,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "vsLinx_MultiDiffusionTiledHiresFix": "MultiDiffusion Tiled Hires Fix",
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: multi-select image loaders (batch/list) and an auto-refreshing last-image loader; image-into-mask-bbox compositing; pixel-art with retro palettes (GameBoy, CGA, NES, Pico-8); exact-factor model upscaling (nearest/bilinear/area/Lanczos); batched VAE Decode/Tiled to cut peak VRAM; an interactive Impact-Pack detailer with per-segment prompts; boolean AND/OR/flip plus bypass/mute nodes driven by a boolean or another node's state; Any to Pipe / Pipe to Any to bundle up to 5 values into one wire; group bookmarks; multiline wildcard text for Impact-Pack; and an rgthree Power LoRA Loader to Image Saver metadata bridge. Also adds settings for model/LoRA hover previews in all loaders (rgthree subdirectory compatible) and a fix for 'Return type mismatch' errors from scheduler-extending nodes like RES4LYF."
-version = "1.13.0"
+version = "1.14.0"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
+++ b/web/docs/vsLinx_AnimaLLLiteTiledSampler.md
@@ -44,6 +44,8 @@ Parameters:
 | method | COMBO | (per_tile only) Resampling (``lanczos``, ``nearest-exact``, ``bilinear``, ``area``, ``bicubic``) used to keep every decoded tile at a uniform size before stitching. |
 | color_match | COMBO | (per_tile only) Per-tile color matching against the source tile, to fix tonal seams (brightness/colour steps between tiles). ``none`` (default), ``mean_std`` (re-scales each tile's per-channel mean/std — fast, simple), ``wavelet`` (keeps the tile's detail but takes the source tile's broad tone — better on textured tiles). |
 | color_match_strength | FLOAT | (per_tile only) How strongly to apply the color match (``0`` = off, ``1`` = full). |
+| vae_decode_tiled | BOOLEAN | (multidiffusion only) Decode the final full-image latent in tiles instead of one pass, so the decode can't spike VRAM (or, on Windows, spill into slow shared system memory). No effect in ``per_tile`` mode, where each tile is already decoded on its own. Only shown when ``sampling_mode`` is ``multidiffusion``. |
+| vae_decode_tile_size | INT | (multidiffusion only) Tile size in pixels for the tiled VAE decode. Only shown when ``sampling_mode`` is ``multidiffusion``. |
 
 Outputs:
 | Parameter | Type | Description |
@@ -56,4 +58,5 @@ Notes:
 - For lower VRAM use more ``rows``/``columns`` (smaller tiles) rather than a tiled VAE — splitting the VAE pass tends to hurt quality without a meaningful speed gain at these tile sizes.
 - In ``per_tile`` mode, tiles sampled independently can drift in overall tone, leaving a faint brightness/colour step (seam) across smooth areas, and can disagree structurally (a "double-exposure" in the overlap). ``color_match`` fixes the tonal step; for structural seams use ``multidiffusion``.
 - ``multidiffusion`` mode removes seams at the source: tiles are re-synced (overlap-averaged in latent space) at every denoising step, so they can't diverge. It does one full-image VAE encode/decode (ComfyUI auto-tiles the VAE if it would otherwise run out of memory) and holds the full latent in memory, so it uses a little more VRAM than ``per_tile``. ``method`` and ``color_match`` are not used in this mode.
+- The ``multidiffusion`` decode is a single full-image pass and is **independent of ``rows``/``columns``** (the grid only tiles the per-step UNet call, not the VAE), so adding tiles won't shrink it. If that final decode pins your VRAM — on Windows it may not raise a clean out-of-memory error and instead crawl by spilling into shared system memory — enable ``vae_decode_tiled`` to force a tiled decode with a bounded ``vae_decode_tile_size``.
 - 4-channel (inpaint) LLLite weights are not supported here since they require a per-tile mask; use the standalone AnimaLLLiteApply node for that case.

--- a/web/docs/vsLinx_MultiDiffusionTiledHiresFix.md
+++ b/web/docs/vsLinx_MultiDiffusionTiledHiresFix.md
@@ -1,0 +1,41 @@
+A model-agnostic <b>MultiDiffusion tiled hires-fix / refiner</b> that re-renders an image in overlapping tiles without producing tile seams. It works on any model (SD / SDXL / Flux / etc.) and needs no extra node packs.
+
+It runs a <b>single sampling pass over the whole image</b>. Every denoising step the latent is split into overlapping tiles, the model is evaluated per tile, and the predictions are <b>averaged in latent space</b> (MultiDiffusion, Bar-Tal et al.). Because the tiles are re-synced every step they can't diverge, so:
+<ul>
+<li>there are <b>no tile seams</b> and no "double-exposure" ghosting to blend away, and</li>
+<li>per-step UNet activations stay <b>tile-sized</b> — you get whole-image coherence at roughly tile-sized peak VRAM, unlike a single full-image pass.</li>
+</ul>
+
+<b>This node does not upscale on its own.</b> Upscale the image first (e.g. <code>Upscale Image By</code> or an upscale-model node), then feed it in here with a low <code>denoise</code> (~0.3–0.5) to refine the detail — the classic "hires fix", done in tiles.
+
+Parameters:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| image | IMAGE | The (already-upscaled) image to refine in tiles. |
+| model | MODEL | The diffusion model. |
+| positive | CONDITIONING | Positive conditioning, shared across all tiles. |
+| negative | CONDITIONING | Negative conditioning, shared across all tiles. |
+| vae | VAE | VAE used to encode the image and decode the result. |
+| seed | INT | Sampling seed. |
+| steps | INT | KSampler steps. |
+| cfg | FLOAT | Classifier-free guidance scale. |
+| sampler_name | COMBO | KSampler sampler. |
+| scheduler | COMBO | KSampler scheduler. |
+| denoise | FLOAT | Denoise strength — for a tiled hires-fix keep this low (e.g. ``0.3``–``0.5``). |
+| rows | INT | Number of tile rows (latent-space grid). |
+| columns | INT | Number of tile columns (latent-space grid). |
+| overlap | FLOAT | Overlap between tiles as a fraction of tile size (added on top of overlap_x/overlap_y). |
+| overlap_x | INT | Extra horizontal overlap in pixels. |
+| overlap_y | INT | Extra vertical overlap in pixels. |
+| vae_decode_tiled | BOOLEAN | Decode the final full-image latent in tiles instead of one pass, so the decode can't spike VRAM (or, on Windows, spill into slow shared system memory). |
+| vae_decode_tile_size | INT | Tile size in pixels for the tiled VAE decode. |
+
+Outputs:
+| Parameter | Type | Description |
+| -------- | ---- | ----------- |
+| image | IMAGE | The refined image. |
+
+Notes:
+- More ``rows``/``columns`` means smaller per-step tiles, which lowers the peak VRAM of each model evaluation. The total number of model evaluations per step is ``rows × columns``, so a finer grid trades a little speed for lower VRAM.
+- The final VAE decode is a single full-image pass and is <b>independent of ``rows``/``columns``</b> (the grid only tiles the per-step model call, not the VAE). If that decode pins your VRAM — on Windows it may not raise a clean out-of-memory error and instead crawl by spilling into shared system memory — enable ``vae_decode_tiled`` with a bounded ``vae_decode_tile_size``.
+- This node delegates to any ``model_function_wrapper`` already installed upstream, so it can stack with other wrapper-based nodes instead of overwriting them.

--- a/web/js/anima_tiled_sampler.js
+++ b/web/js/anima_tiled_sampler.js
@@ -1,0 +1,74 @@
+import { app } from "../../../scripts/app.js";
+
+// Anima LLLite Tiled ControlNet Sampler: the tiled-VAE-decode widgets only
+// apply in multidiffusion mode (per_tile decodes each small tile on its own),
+// so hide them unless sampling_mode === "multidiffusion".
+
+const NODE_CLASS = "vsLinx_AnimaLLLiteTiledSampler";
+const MODE_WIDGET = "sampling_mode";
+const MULTIDIFFUSION = "multidiffusion";
+const TILED_WIDGETS = ["vae_decode_tiled", "vae_decode_tile_size"];
+const HIDDEN_TYPE = "vslinxhidden";
+
+const findWidget = (node, name) => node.widgets?.find((w) => w.name === name);
+
+const hideWidget = (w) => {
+  if (!w || w.type === HIDDEN_TYPE) return;
+  w._origType = w.type;
+  w._origComputeSize = w.computeSize;
+  w.type = HIDDEN_TYPE;
+  // [0, -4] cancels the inter-widget spacing so no gap is left behind.
+  w.computeSize = () => [0, -4];
+  w.hidden = true;
+};
+
+const showWidget = (w) => {
+  if (!w || w.type !== HIDDEN_TYPE) return;
+  w.type = w._origType;
+  w.computeSize = w._origComputeSize;
+  w.hidden = false;
+};
+
+const updateVisibility = (node) => {
+  const show = findWidget(node, MODE_WIDGET)?.value === MULTIDIFFUSION;
+  for (const name of TILED_WIDGETS) {
+    const w = findWidget(node, name);
+    show ? showWidget(w) : hideWidget(w);
+  }
+  // Recompute height (keep the user's width) so the node shrinks/grows to fit.
+  node.setSize([node.size[0], node.computeSize()[1]]);
+  node.setDirtyCanvas(true, true);
+};
+
+app.registerExtension({
+  name: "vslinx.animaTiledSampler.tiledVaeToggle",
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== NODE_CLASS) return;
+
+    const onNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const r = onNodeCreated?.apply(this, arguments);
+      const node = this;
+      const mode = findWidget(node, MODE_WIDGET);
+      if (mode) {
+        const origCallback = mode.callback;
+        mode.callback = function () {
+          const ret = origCallback?.apply(this, arguments);
+          updateVisibility(node);
+          return ret;
+        };
+      }
+      // Defer so widgets are fully in place on a freshly added node.
+      requestAnimationFrame(() => updateVisibility(node));
+      return r;
+    };
+
+    // Re-apply after a saved workflow restores widget values.
+    const onConfigure = nodeType.prototype.onConfigure;
+    nodeType.prototype.onConfigure = function () {
+      const r = onConfigure?.apply(this, arguments);
+      requestAnimationFrame(() => updateVisibility(this));
+      return r;
+    };
+  },
+});


### PR DESCRIPTION
# Add MultiDiffusion Tiled Hires Fix node + tiled VAE decode for multidiffusion

## Summary
Two related additions to the tiled-sampling family:

1. A new model-agnostic **MultiDiffusion Tiled Hires Fix** node.
2. An optional **tiled VAE decode** for the **Anima LLLite Tiled ControlNet Sampler**'s `multidiffusion` mode.

Both are opt-in and leave existing graphs unchanged.

## MultiDiffusion Tiled Hires Fix (new node)
A standalone tiled hires-fix / refiner that works on **any** model (SD / SDXL / Flux / etc.) and needs no extra node packs. It re-renders an image in overlapping tiles **without** producing tile seams.

It runs a single sampling pass over the whole image: every denoising step the latent is split into overlapping tiles, the model is evaluated per tile, and the predictions are averaged in latent space (MultiDiffusion). Because the tiles are re-synced every step they can't diverge, so:
- there are **no tile seams** and no "double-exposure" ghosting to blend away, and
- per-step UNet activations stay **tile-sized** — you get whole-image coherence at roughly tile-sized peak VRAM, unlike a single full-image pass.

It doesn't upscale on its own: upscale the image first, then refine it here with a low `denoise` (~0.3–0.5).

**Discoverability:** because many users don't know the term "multidiffusion", the node ships with search aliases like `hires fix`, `hi-res fix`, `tiled hires fix`, `tiled diffusion`, `tiled upscale`, `mixture of diffusers` and similar, so it surfaces in node search under the words people actually look for.

**Implementation notes:**
- The MultiDiffusion tiling math (`_md_spans` / `_md_weight_1d`) is shared with the existing Anima sampler, so there's a single source of truth for it and the existing node is untouched.
- It delegates to any `model_function_wrapper` already installed upstream, so it can stack with other wrapper-based nodes instead of clobbering them.

## Tiled VAE decode for multidiffusion
The `multidiffusion` mode's final VAE decode is a single full-image pass and is **independent of `rows`/`columns`** (the grid only tiles the per-step model call, not the VAE), so adding tiles doesn't shrink it. On large images that decode can pin VRAM — and on Windows it may not raise a clean out-of-memory error, instead crawling for minutes by spilling into shared system memory, so ComfyUI's automatic on-OOM tiled fallback never triggers.

This adds an opt-in `vae_decode_tiled` toggle (with `vae_decode_tile_size`) that forces a tiled decode **proactively** instead of waiting for an OOM, keeping the final decode bounded. It's default-off, applies only to `multidiffusion` (per_tile already decodes each tile on its own), and the two fields are hidden via JS unless `sampling_mode` is `multidiffusion` so they don't clutter the node.

## Docs
README and the in-Comfy node docs are updated for both additions; the new node's doc is fully self-contained.
