### PR TITLE
fix(multidiffusion-hires): back-fill VAE attrs for ComfyUI 0.27.0 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.15.1
+- fixed ``MultiDiffusion Tiled Hires Fix`` throwing ``AttributeError: 'CustomVAE' object has no attribute 'format_encoded'`` (or ``handles_tiling``) after updating to ComfyUI 0.27.0. That release added new attributes to ComfyUI's base VAE that out-of-date custom-VAE packs (e.g. [ComfyUI-VAE-Utils](https://github.com/spacepxl/ComfyUI-VAE-Utils), whose ``CustomVAE`` copies an older VAE init and never calls ``super().__init__()``) don't set, so encoding/decoding through them raised an error. The node now back-fills only the missing attributes with ComfyUI's own defaults before use; up-to-date VAEs are left untouched.
+
 ### v.1.15.0
 - ``MultiDiffusion Tiled Hires Fix`` now works with **upscale VAEs** loaded through node packs like [ComfyUI-VAE-Utils](https://github.com/spacepxl/ComfyUI-VAE-Utils) (e.g. the Wan2.1 ``upscale2x`` image VAE). These VAEs' decoders emit extra channels (``3 × k²``) that have to be ``pixel_shuffle``-d back into a ``k``-times larger RGB image — a step the stock VAE Decode doesn't do, so previously the node returned a broken multi-channel result with them. The node now auto-detects such a VAE and switches to a decode that matches that pack's own decode node (channel unshuffle + range guard), while every normal VAE keeps the exact same decode path as before. The ``vae_decode_tiled`` / ``vae_decode_tile_size`` options are honored on this path too.
 

--- a/nodes/multidiffusion_tiled_hires.py
+++ b/nodes/multidiffusion_tiled_hires.py
@@ -26,6 +26,22 @@ import torch
 from .anima_lllite_tiled_sampler import _md_spans, _md_weight_1d
 
 
+def _ensure_vae_compat(vae):
+    """Back-fill VAE attributes that a newer ComfyUI's base ``VAE.encode`` /
+    ``VAE.decode`` expect but that out-of-date custom-VAE packs don't set.
+
+    ComfyUI-VAE-Utils' ``CustomVAE`` copies an older ``VAE.__init__`` and never
+    calls ``super().__init__()``, so attributes added to the base VAE later (e.g.
+    ``handles_tiling`` / ``format_encoded`` in ComfyUI 0.27.0) are missing on it
+    and raise ``AttributeError`` the moment we encode/decode with it. We only
+    fill attributes that are actually absent, using the base VAE's own defaults,
+    so a stock / up-to-date VAE is left completely untouched.
+    """
+    for attr, default in (("handles_tiling", False), ("format_encoded", None)):
+        if not hasattr(vae, attr):
+            setattr(vae, attr, default)
+
+
 def _is_upscale_vae(vae):
     """Detect a VAE-Utils-style upscale VAE.
 
@@ -180,6 +196,10 @@ class VSLinx_MultiDiffusionTiledHiresFix:
         """One MultiDiffusion pass over the whole latent: tile + overlap-average
         the model's prediction at every denoising step."""
         from nodes import common_ksampler
+
+        # Make sure the VAE has the attributes newer ComfyUI expects, so
+        # out-of-date custom VAEs (e.g. VAE-Utils) don't AttributeError on encode/decode.
+        _ensure_vae_compat(vae)
 
         # Encode the whole image once (ComfyUI auto-tiles the VAE if it would OOM).
         latent = vae_encoder.encode(vae, img)[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: multi-select image loaders (batch/list) and an auto-refreshing last-image loader; image-into-mask-bbox compositing; pixel-art with retro palettes (GameBoy, CGA, NES, Pico-8); exact-factor model upscaling (nearest/bilinear/area/Lanczos); batched VAE Decode/Tiled to cut peak VRAM; an interactive Impact-Pack detailer with per-segment prompts; boolean AND/OR/flip plus bypass/mute nodes driven by a boolean or another node's state; Any to Pipe / Pipe to Any to bundle up to 5 values into one wire; group bookmarks; multiline wildcard text for Impact-Pack; and an rgthree Power LoRA Loader to Image Saver metadata bridge. Also adds settings for model/LoRA hover previews in all loaders (rgthree subdirectory compatible) and a fix for 'Return type mismatch' errors from scheduler-extending nodes like RES4LYF."
-version = "1.15.0"
+version = "1.15.1"
 license = { file = "LICENSE" }
 
 [project.urls]


### PR DESCRIPTION
## Summary

The `MultiDiffusion Tiled Hires Fix` node crashed with `AttributeError: 'CustomVAE' object has no attribute 'format_encoded'` (or `handles_tiling`) after updating to ComfyUI 0.27.0, whenever the connected VAE came from an out-of-date custom-VAE pack. The node now back-fills the missing attributes before use, so those VAEs encode and decode again.

## Background

ComfyUI 0.27.0 added new attributes to the base `VAE` class (notably `handles_tiling` and `format_encoded`), and the base `VAE.encode()` / `VAE.decode()` now read them on every call.

Some custom-VAE packs — e.g. [ComfyUI-VAE-Utils](https://github.com/spacepxl/ComfyUI-VAE-Utils), whose `CustomVAE` copies an older `VAE.__init__` and never calls `super().__init__()` — don't set these newer attributes. As soon as the node encodes or decodes through such a VAE, the missing attribute raises `AttributeError`. This affects any encode/decode with that VAE on 0.27.0, not just this node; it simply surfaces here because the node encodes the image first.

## Changes

- Added a small compatibility shim that runs before the VAE is used. It fills only the attributes that are actually absent (`handles_tiling`, `format_encoded`) with ComfyUI's own base defaults, using `hasattr` guards so a stock / up-to-date VAE is left completely untouched. Because `handles_tiling` defaults to `False`, the newer tiling-ownership code paths are never entered, so no further missing-method issues arise.
- The shim is a no-op once the upstream pack is fixed (the attributes will already be present), so it doesn't conflict with a proper fix in that pack.

## Notes

- This is a defensive shim in our node, not a substitute for the packs syncing with the newer base VAE; the root-cause fix belongs upstream, but the shim keeps the node robust regardless.
- Version bumped to `1.15.1` with a matching changelog entry.