### PR TITLE
fix(bypass-on-bool): check for upstream node's state before evaluating boolean value

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ You can find an example workflow [here](https://github.com/user-attachments/asse
 <img width="512" height="512" src="https://github.com/user-attachments/assets/8c4d8a46-42e9-4da0-ab72-7d00b5bd7d8f"/>
 
 ## Changelog
+### v.1.16.1
+- fixed ``Forward/Bypass on Boolean (Any)`` and ``Forward/Mute on Boolean (Any)`` ignoring the bypass/mute state of upstream boolean nodes: a muted or bypassed source (e.g. one of the two inputs of a ``Boolean AND Operator``) is now read as False / passed through like ComfyUI does at execution time, so the toggled downstream node matches what the workflow actually computes.
+
 ### v.1.16.0
 - added new ``Int to Bool (Threshold)``-Node in the ``vsLinx/boolean`` group. Like a classic int-to-bool conversion, but with a ``threshold`` field: it outputs True when the input ``value`` is greater than or equal to ``threshold`` (default 1, so 1-or-above → True) and False otherwise, letting you gate on any cutoff instead of only ``>= 1``.
 - reworked the ``Group Bookmarks`` node into a general ``Bookmarks`` node (renamed; the node identifier is unchanged, so existing workflows keep working). You can now bookmark **individual nodes** in addition to whole groups: the redesigned "Manage Bookmarks" modal shows a searchable **Groups & Nodes** tree where each group can be expanded (▸) to reveal and bookmark the nodes inside it, with ungrouped nodes listed at the bottom. Active bookmarks are tagged **GROUP**/**NODE**, stay reorderable by drag, and clicking a node bookmark in the side panel jumps to and selects that node. Old group-only bookmarks (including sections) are migrated automatically.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-vslinx-nodes"
 description = "Custom ComfyUI nodes to streamline workflows: multi-select image loaders (batch/list) and an auto-refreshing last-image loader; image-into-mask-bbox compositing; pixel-art with retro palettes (GameBoy, CGA, NES, Pico-8); exact-factor model upscaling (nearest/bilinear/area/Lanczos); batched VAE Decode/Tiled to cut peak VRAM; an interactive Impact-Pack detailer with per-segment prompts; boolean AND/OR/flip plus bypass/mute nodes driven by a boolean or another node's state; Any to Pipe / Pipe to Any to bundle up to 5 values into one wire; group bookmarks; multiline wildcard text for Impact-Pack; and an rgthree Power LoRA Loader to Image Saver metadata bridge. Also adds settings for model/LoRA hover previews in all loaders (rgthree subdirectory compatible) and a fix for 'Return type mismatch' errors from scheduler-extending nodes like RES4LYF."
-version = "1.16.0"
+version = "1.16.1"
 license = { file = "LICENSE" }
 
 [project.urls]

--- a/web/js/bypass_helper.js
+++ b/web/js/bypass_helper.js
@@ -255,6 +255,30 @@ function findParentNode(subgraph) {
   return search(app.graph);
 }
 
+// Litegraph type strings match loosely: "*" is a wildcard on either side and
+// comparison is case-insensitive (BOOLEAN vs boolean).
+function typesMatch(a, b) {
+  if (!a || !b) return true;
+  const ta = String(a).toUpperCase();
+  const tb = String(b).toUpperCase();
+  return ta === "*" || tb === "*" || ta === tb;
+}
+
+// Emulate ComfyUI's BYPASS pass-through: an output of type T is fed by the
+// first input of the same type. If no matching input exists (or it isn't
+// connected) the node emits None, which the backend evaluates as False.
+function resolveBypassPassthrough(graph, src, originSlot, seen) {
+  const outType = src.outputs?.[originSlot]?.type;
+  for (const inp of (src.inputs || [])) {
+    if (!typesMatch(inp.type, outType)) continue;
+    const lid = inp.link ?? (inp.links?.[0] ?? null);
+    if (lid == null) return false;
+    const v = resolveBooleanAtLink(graph, lid, new Set(seen));
+    return (v == null) ? null : !!v;
+  }
+  return false;
+}
+
 function resolveBooleanAtLink(graph, linkId, seen = new Set()) {
   const link = graph?.links?.[linkId];
   if (!link) return null;
@@ -275,6 +299,14 @@ function resolveBooleanAtLink(graph, linkId, seen = new Set()) {
   const key = `${src.id}:${link.origin_slot}`;
   if (seen.has(key)) return null;
   seen.add(key);
+
+  // 0. Muted / bypassed source: the node never produces a value, so reading its
+  //    widget or walking its inputs would report a state the backend never sees.
+  //    MUTE emits nothing (treated as False here, matching what downstream
+  //    boolean nodes evaluate); BYPASS forwards a same-typed input instead.
+  const srcMode = src.mode ?? MODE_ALWAYS;
+  if (srcMode === MODE_NEVER) return false;
+  if (srcMode === MODE_BYPASS) return resolveBypassPassthrough(graph, src, link.origin_slot, seen);
 
   // 1. Known vsLinx logic nodes (AND / OR / Flip)
   const evalFn = BOOLEAN_NODE_EVAL[src.type];


### PR DESCRIPTION
Bug reported here: https://github.com/vslinx/ComfyUI-vslinx-nodes/issues/33

## Problem

`Forward/Bypass on Boolean (Any)` (and its mute variant) walk the upstream graph in the frontend to figure out the boolean that drives the downstream bypass/mute. That walk only looked at node *types* and widget values, never at a node's mode.

Reported case: two Boolean nodes (both `true`) feed a `Boolean AND Operator`, which feeds `Forward/Bypass on Boolean (Any)`. Muting or bypassing one of the two Booleans makes the AND return `false` at execution time, but the helper kept reading `true && true` and left the downstream node bypassed.

## Cause

`resolveBooleanAtLink()` in `web/js/bypass_helper.js` resolved a source node without checking `src.mode`, so a bypassed Boolean node still reported its widget value. The backend sees `None` there, and `VSLinx_BooleanAndOperator._as_bool(None)` is `False`, so frontend and backend disagreed.

## Change

Added a mode check at the top of the resolve step, before the type dispatch:

* `MODE_NEVER` (mute): resolves to `false`, the node emits nothing.
* `MODE_BYPASS`: new `resolveBypassPassthrough()` mirrors ComfyUI's pass-through rule, feeding an output of type T from the first input of the same type, and resolving to `false` when there is no matching or connected input.
* New `typesMatch()` helper for the slot comparison, treating `*` as a wildcard and ignoring case.

The check runs inside the existing recursion, so it applies at any depth: a bypassed `Boolean Flip` forwards its input unflipped, a bypassed AND forwards `boolean_a`, and anything muted upstream collapses to `false`.